### PR TITLE
test(e2e): add Sprint 1 Day 7 E2E flow

### DIFF
--- a/backend/tests/e2e/test_e2e_01_flow.py
+++ b/backend/tests/e2e/test_e2e_01_flow.py
@@ -1,0 +1,259 @@
+import uuid
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.db import SessionLocal
+from app.main import app
+from app.models.activity import ActivityType
+from app.models.item import Item
+from app.models.microconcept import MicroConcept
+from app.models.role import Role
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import AcademicYear, Term
+from app.models.tutor import Tutor
+from app.models.user import User
+
+client = TestClient(app)
+
+MOCK_PDF_TEXT = "Contenido de prueba de matemáticas: suma, resta y números enteros."
+MOCK_E2_RESPONSE = {"summary": "Resumen", "chunks": ["Chunk 1", "Chunk 2"]}
+MOCK_E4_RESPONSE = {
+    "items": [
+        {
+            "type": "multiple_choice",
+            "stem": "¿Cuál es el resultado de 1+1?",
+            "options": ["1", "2", "3", "4"],
+            "correct_answer": "2",
+            "explanation": "1+1=2.",
+        }
+    ]
+}
+
+
+@pytest.fixture
+def db_session() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _create_mock_response(content_dict: dict) -> MagicMock:
+    import json
+
+    mock_msg = MagicMock()
+    mock_msg.message.content = json.dumps(content_dict)
+    mock_choice = MagicMock()
+    mock_choice.choices = [mock_msg]
+    return mock_choice
+
+
+def test_e2e_01_flow_content_to_report(db_session: Session):
+    uid = uuid.uuid4()
+
+    role_student = db_session.query(Role).filter_by(name="Student").first()
+    if not role_student:
+        role_student = Role(name="Student")
+        db_session.add(role_student)
+
+    role_tutor = db_session.query(Role).filter_by(name="Tutor").first()
+    if not role_tutor:
+        role_tutor = Role(name="Tutor")
+        db_session.add(role_tutor)
+
+    db_session.commit()
+
+    tutor_user = User(
+        id=uuid.uuid4(),
+        email=f"t_{uid}@e2e.test",
+        hashed_password="x",
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    student_user = User(
+        id=uuid.uuid4(),
+        email=f"s_{uid}@e2e.test",
+        hashed_password="x",
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add_all([tutor_user, student_user])
+    db_session.flush()
+
+    tutor = Tutor(user_id=tutor_user.id, display_name="Tutor E2E")
+    student = Student(user_id=student_user.id)
+    db_session.add_all([tutor, student])
+
+    year = AcademicYear(
+        name=f"2025-2026-{uid}",
+        start_date=date(2025, 9, 1),
+        end_date=date(2026, 6, 30),
+    )
+    db_session.add(year)
+    db_session.flush()
+
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    subject = Subject(name=f"Math E2E {uid}", tutor_id=tutor_user.id)
+    db_session.add_all([term, subject])
+
+    activity_type = db_session.query(ActivityType).filter_by(code="QUIZ").first()
+    if not activity_type:
+        activity_type = ActivityType(code="QUIZ", name="Quiz", active=True)
+        db_session.add(activity_type)
+
+    db_session.commit()
+
+    files = {"file": ("test.pdf", b"fake pdf", "application/pdf")}
+    data = {
+        "subject_id": str(subject.id),
+        "term_id": str(term.id),
+        "upload_type": "pdf",
+        "tutor_id": str(tutor.id),
+    }
+    upload_res = client.post("/api/v1/content/uploads", files=files, data=data)
+    assert upload_res.status_code == 201
+    upload_id = upload_res.json()["id"]
+
+    settings.OPENAI_API_KEY = "fake-key"
+    with (
+        patch("app.pipelines.processing.extract_text_from_pdf", return_value=MOCK_PDF_TEXT),
+        patch("app.pipelines.processing.os.path.exists", return_value=True),
+        patch("app.services.llm_service.openai.OpenAI") as mock_openai,
+    ):
+        mock_instance = mock_openai.return_value
+        mock_instance.chat.completions.create.side_effect = [
+            _create_mock_response(MOCK_E2_RESPONSE),
+            _create_mock_response(MOCK_E4_RESPONSE),
+            _create_mock_response(MOCK_E4_RESPONSE),
+        ]
+
+        process_res = client.post(f"/api/v1/content/uploads/{upload_id}/process")
+        assert process_res.status_code == 202
+
+    db_session.expire_all()
+
+    microconcepts = (
+        db_session.query(MicroConcept)
+        .filter(MicroConcept.subject_id == subject.id, MicroConcept.term_id == term.id)
+        .all()
+    )
+    assert any(mc.name == "General" for mc in microconcepts)
+
+    items = db_session.query(Item).filter(Item.content_upload_id == uuid.UUID(upload_id)).all()
+    assert len(items) >= 2
+    assert all(item.microconcept_id is not None for item in items)
+
+    session_res = client.post(
+        "/api/v1/activities/sessions",
+        json={
+            "student_id": str(student.id),
+            "activity_type_id": str(activity_type.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "topic_id": None,
+            "item_count": 2,
+            "device_type": "web",
+        },
+    )
+    assert session_res.status_code == 200
+    session_id = session_res.json()["id"]
+
+    start_time = datetime.utcnow()
+    end_time = datetime.utcnow()
+    for item in items[:2]:
+        response_res = client.post(
+            f"/api/v1/activities/sessions/{session_id}/responses",
+            json={
+                "student_id": str(student.id),
+                "item_id": str(item.id),
+                "subject_id": str(subject.id),
+                "term_id": str(term.id),
+                "topic_id": None,
+                "microconcept_id": None,
+                "activity_type_id": str(activity_type.id),
+                "is_correct": False,
+                "duration_ms": 40000,
+                "attempt_number": 1,
+                "response_normalized": "x",
+                "hint_used": None,
+                "difficulty_at_time": None,
+                "timestamp_start": start_time.isoformat(),
+                "timestamp_end": end_time.isoformat(),
+            },
+        )
+        assert response_res.status_code == 200
+
+    end_res = client.post(f"/api/v1/activities/sessions/{session_id}/end")
+    assert end_res.status_code == 200
+
+    metrics_res = client.get(
+        f"/api/v1/metrics/students/{student.id}/metrics",
+        params={"subject_id": str(subject.id), "term_id": str(term.id)},
+    )
+    assert metrics_res.status_code == 200
+    metrics_payload = metrics_res.json()
+    assert metrics_payload["accuracy"] < 0.5
+    assert metrics_payload["median_response_time_ms"] > 30000
+
+    mastery_res = client.get(
+        f"/api/v1/metrics/students/{student.id}/mastery",
+        params={"subject_id": str(subject.id), "term_id": str(term.id)},
+    )
+    assert mastery_res.status_code == 200
+    mastery_payload = mastery_res.json()
+    assert len(mastery_payload) >= 1
+    assert any(state["total_events"] >= 1 for state in mastery_payload)
+
+    recs_res = client.get(
+        f"/api/v1/recommendations/students/{student.id}",
+        params={"subject_id": str(subject.id), "term_id": str(term.id)},
+    )
+    assert recs_res.status_code == 200
+    recs = recs_res.json()
+    assert len(recs) >= 1
+    assert any(rec["rule_id"] == "R01" for rec in recs)
+
+    r01 = next(rec for rec in recs if rec["rule_id"] == "R01")
+    decision_res = client.post(
+        f"/api/v1/recommendations/{r01['id']}/decision",
+        json={
+            "decision": "accepted",
+            "notes": "OK",
+            "tutor_id": str(tutor.id),
+            "recommendation_id": r01["id"],
+        },
+    )
+    assert decision_res.status_code == 200
+    assert decision_res.json()["decision"] == "accepted"
+
+    get_rec_res = client.get(f"/api/v1/recommendations/{r01['id']}")
+    assert get_rec_res.status_code == 200
+    assert get_rec_res.json()["status"] == "accepted"
+
+    report_res = client.post(
+        f"/api/v1/reports/students/{student.id}/generate",
+        params={
+            "tutor_id": str(tutor.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "generate_recommendations": "true",
+        },
+    )
+    assert report_res.status_code == 201
+    report = report_res.json()
+    assert report["student_id"] == str(student.id)
+    assert any(section["section_type"] == "mastery" for section in report["sections"])
+
+    latest_res = client.get(
+        f"/api/v1/reports/students/{student.id}/latest",
+        params={"tutor_id": str(tutor.id), "subject_id": str(subject.id), "term_id": str(term.id)},
+    )
+    assert latest_res.status_code == 200
+    assert latest_res.json()["id"] == report["id"]

--- a/backend/tests/test_llm_pipeline.py
+++ b/backend/tests/test_llm_pipeline.py
@@ -9,6 +9,7 @@ from app.main import app
 from app.models.content import ContentUpload, ContentUploadType
 from app.models.item import Item
 from app.models.knowledge import KnowledgeChunk, KnowledgeEntry
+from app.models.microconcept import MicroConcept
 from app.models.role import Role
 from app.models.subject import Subject
 from app.models.term import AcademicYear, Term
@@ -153,6 +154,14 @@ def test_process_pipeline_success(db_session):
         items = db_session.query(Item).filter_by(content_upload_id=upload_id).all()
         assert len(items) == 2
         assert items[0].stem == "What is fun?"
+        assert all(item.microconcept_id is not None for item in items)
+
+        microconcepts = (
+            db_session.query(MicroConcept)
+            .filter(MicroConcept.subject_id == subject.id, MicroConcept.term_id == term.id)
+            .all()
+        )
+        assert len(microconcepts) >= 1
 
         # 5. Verify GET /items Endpoint
         response_items = client.get(f"/api/v1/content/uploads/{upload_id}/items")


### PR DESCRIPTION
## Qu?
- Asigna autom?ticamente un microconcepto "General" a los ?tems generados por el pipeline (evita dominio vac?o).
- A?ade test E2E-01 que cubre el flujo: upload -> pipeline (mock) -> sesi?n -> eventos -> m?tricas/dominio -> recomendaciones -> decisi?n tutor -> reporte.

## Por qu?
- D?a 7 Sprint 1: validaci?n end-to-end y estabilizaci?n.

## Checks
- Backend CI (ruff + pytest)
