### PR TITLE
feat(auth): add /auth/me and remove hardcoded IDs

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm import Session
 from app.core import security
 from app.core.config import settings
 from app.core.db import get_db
-from app.schemas.auth import Login, Token
+from app.core.deps import get_current_active_user
+from app.models.role import Role
+from app.models.student import Student
+from app.models.tutor import Tutor
+from app.models.user import User
+from app.schemas.auth import Login, Token, UserMe
 from app.services.auth_service import AuthService
 
 router = APIRouter()
@@ -34,3 +39,31 @@ def login_access_token(
         "access_token": access_token,
         "token_type": "bearer",
     }
+
+
+@router.get("/auth/me", response_model=UserMe)
+def get_me(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> UserMe:
+    role_name: str | None = None
+    if current_user.role_id:
+        role = db.get(Role, current_user.role_id)
+        if role:
+            role_name = role.name
+
+    tutor = db.query(Tutor).filter(Tutor.user_id == current_user.id).first()
+    student = (
+        db.query(Student)
+        .filter((Student.user_id == current_user.id) | (Student.id == current_user.id))
+        .first()
+    )
+
+    return UserMe(
+        id=current_user.id,
+        email=current_user.email,
+        full_name=current_user.full_name,
+        role=role_name,
+        tutor_id=tutor.id if tutor else None,
+        student_id=student.id if student else None,
+    )

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -10,7 +10,9 @@ from passlib.context import CryptContext
 
 from app.core.config import settings
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+# NOTE: bcrypt backend has compatibility issues in some CI environments (see passlib/bcrypt).
+# PBKDF2-SHA256 is deterministic and avoids platform-specific bcrypt backend problems.
+pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
 
 ALGORITHM = "HS256"
 
@@ -34,7 +36,10 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
     Verify a password against a hash.
     """
-    return pwd_context.verify(plain_password, hashed_password)
+    try:
+        return pwd_context.verify(plain_password, hashed_password)
+    except Exception:
+        return False
 
 
 def get_password_hash(password: str) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.api.v1 import auth, events
 from app.core.db import get_db
-from app.routers import activity, content, metrics, microconcepts, recommendations, reports
+from app.routers import activity, catalog, content, metrics, microconcepts, recommendations, reports
 
 app = FastAPI(
     title="DECIES API",
@@ -27,6 +27,7 @@ app.include_router(metrics.router, prefix="/api/v1")
 app.include_router(microconcepts.router, prefix="/api/v1")
 app.include_router(recommendations.router, prefix="/api/v1")
 app.include_router(reports.router, prefix="/api/v1")
+app.include_router(catalog.router, prefix="/api/v1")
 
 # CORS middleware
 app.add_middleware(

--- a/backend/app/routers/catalog.py
+++ b/backend/app/routers/catalog.py
@@ -1,0 +1,115 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.db import get_db
+from app.core.deps import get_current_active_user
+from app.models.role import Role
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import Term
+from app.models.user import User
+from app.schemas.catalog import StudentSummary, SubjectSummary, TermSummary
+
+router = APIRouter(prefix="/catalog", tags=["catalog"])
+
+
+def _get_role_name(db: Session, user: User) -> str | None:
+    if not user.role_id:
+        return None
+    role = db.get(Role, user.role_id)
+    return role.name if role else None
+
+
+@router.get("/terms", response_model=list[TermSummary])
+def list_terms(
+    active: bool | None = True,
+    db: Session = Depends(get_db),
+    _current_user: User = Depends(get_current_active_user),
+):
+    query = db.query(Term)
+    if active is True:
+        query = query.filter(Term.status == "active")
+    return query.order_by(Term.code).all()
+
+
+@router.get("/subjects", response_model=list[SubjectSummary])
+def list_subjects(
+    mine: bool = True,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    query = db.query(Subject)
+    if mine:
+        query = query.filter(Subject.tutor_id == current_user.id)
+    return query.order_by(Subject.name).all()
+
+
+@router.get("/students", response_model=list[StudentSummary])
+def list_students(
+    mine: bool = True,
+    subject_id: uuid.UUID | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    role_name = (_get_role_name(db, current_user) or "").casefold()
+
+    if role_name == "student":
+        student = (
+            db.query(Student)
+            .filter((Student.user_id == current_user.id) | (Student.id == current_user.id))
+            .first()
+        )
+        if not student:
+            return []
+        return [
+            StudentSummary(
+                id=student.id,
+                user_id=student.user_id,
+                subject_id=student.subject_id,
+                enrollment_date=student.enrollment_date,
+                email=current_user.email,
+                full_name=current_user.full_name,
+            )
+        ]
+
+    if role_name != "tutor":
+        raise HTTPException(status_code=403, detail="Role not allowed")
+
+    subjects_query = db.query(Subject).filter(Subject.tutor_id == current_user.id)
+    if subject_id:
+        subjects_query = subjects_query.filter(Subject.id == subject_id)
+    subject_ids = [row.id for row in subjects_query.all()]
+
+    if not subject_ids and mine:
+        return []
+
+    student_query = db.query(Student)
+    if mine and subject_ids:
+        student_query = student_query.filter(Student.subject_id.in_(subject_ids))
+    elif subject_id:
+        student_query = student_query.filter(Student.subject_id == subject_id)
+
+    students = student_query.order_by(Student.enrollment_date.desc().nullslast()).all()
+
+    users = {}
+    user_ids = [s.user_id for s in students if s.user_id]
+    if user_ids:
+        for user in db.query(User).filter(User.id.in_(user_ids)).all():
+            users[user.id] = user
+
+    results: list[StudentSummary] = []
+    for student in students:
+        user = users.get(student.user_id) if student.user_id else None
+        results.append(
+            StudentSummary(
+                id=student.id,
+                user_id=student.user_id,
+                subject_id=student.subject_id,
+                enrollment_date=student.enrollment_date,
+                email=user.email if user else None,
+                full_name=user.full_name if user else None,
+            )
+        )
+    return results

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -89,9 +89,11 @@ def upload_content(
 
 
 @router.get("/uploads", response_model=list[ContentUploadResponse])
-def get_uploads(db: Session = Depends(get_db)):
-    # Filter by Tutor...
-    tutor = db.query(Tutor).first()
+def get_uploads(
+    tutor_id: uuid.UUID | None = None,
+    db: Session = Depends(get_db),
+):
+    tutor = db.get(Tutor, tutor_id) if tutor_id else db.query(Tutor).first()
     if not tutor:
         return []
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Optional
 
 from pydantic import BaseModel, EmailStr
@@ -15,3 +16,12 @@ class TokenPayload(BaseModel):
 class Login(BaseModel):
     email: EmailStr
     password: str
+
+
+class UserMe(BaseModel):
+    id: uuid.UUID
+    email: EmailStr
+    full_name: str | None = None
+    role: str | None = None
+    tutor_id: uuid.UUID | None = None
+    student_id: uuid.UUID | None = None

--- a/backend/app/schemas/catalog.py
+++ b/backend/app/schemas/catalog.py
@@ -1,0 +1,32 @@
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SubjectSummary(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TermSummary(BaseModel):
+    id: uuid.UUID
+    code: str
+    name: str
+    status: str
+    start_date: date | None = None
+    end_date: date | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class StudentSummary(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID | None = None
+    subject_id: uuid.UUID | None = None
+    enrollment_date: datetime | None = None
+    email: str | None = None
+    full_name: str | None = None

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -61,7 +61,7 @@ def seed_db():
             db.add(user_tutor)
             db.flush()  # Ensure user is pending insertion before tutor refers to it?
             logger.info(f"Created User: {tutor_email}")
-        elif not user_tutor.hashed_password.startswith("$2"):
+        elif not user_tutor.hashed_password.startswith("$pbkdf2-sha256$"):
             user_tutor.hashed_password = get_password_hash(default_password)
             logger.info("Updated Tutor password hash")
 
@@ -89,7 +89,7 @@ def seed_db():
             )
             db.add(user_student)
             logger.info(f"Created User: {student_email}")
-        elif not user_student.hashed_password.startswith("$2"):
+        elif not user_student.hashed_password.startswith("$pbkdf2-sha256$"):
             user_student.hashed_password = get_password_hash(default_password)
             logger.info("Updated Student password hash")
 

--- a/backend/tests/test_auth_me.py
+++ b/backend/tests/test_auth_me.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_login_and_me_and_catalog():
+    token_res = client.post(
+        "/api/v1/login/access-token",
+        json={"email": "tutor@decies.com", "password": "decies"},
+    )
+    assert token_res.status_code == 200
+    token = token_res.json()["access_token"]
+
+    headers = {"Authorization": f"Bearer {token}"}
+
+    me_res = client.get("/api/v1/auth/me", headers=headers)
+    assert me_res.status_code == 200
+    me = me_res.json()
+    assert me["email"] == "tutor@decies.com"
+    assert me["tutor_id"] is not None
+
+    subjects_res = client.get("/api/v1/catalog/subjects", headers=headers, params={"mine": "true"})
+    assert subjects_res.status_code == 200
+    assert len(subjects_res.json()) >= 1
+
+    terms_res = client.get("/api/v1/catalog/terms", headers=headers, params={"active": "true"})
+    assert terms_res.status_code == 200
+    assert len(terms_res.json()) >= 1
+
+    students_res = client.get("/api/v1/catalog/students", headers=headers, params={"mine": "true"})
+    assert students_res.status_code == 200
+    assert len(students_res.json()) >= 1

--- a/frontend/src/app/tutor/page.tsx
+++ b/frontend/src/app/tutor/page.tsx
@@ -1,20 +1,26 @@
 "use client";
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import AuthPanel from '../../components/auth/AuthPanel';
 import UploadForm from '../../components/tutor/UploadForm';
 import UploadList from '../../components/tutor/UploadList';
 import MetricsDashboard from '../../components/tutor/MetricsDashboard';
 import RecommendationList from '../../components/tutor/RecommendationList';
 import TutorReportPanel from '../../components/tutor/TutorReportPanel';
+import { AuthMe } from '../../services/auth';
+import { fetchStudents, fetchSubjects, fetchTerms, StudentSummary, SubjectSummary, TermSummary } from '../../services/catalog';
 
 export default function TutorPage() {
     const [activeTab, setActiveTab] = useState<'content' | 'metrics' | 'recommendations' | 'reports'>('content');
 
-    // Hardcoded for MVP - synced with actual DB content from user session
-    const TUTOR_ID = "2f724489-4889-444b-b098-d7624c5561fd"; // Valid Tutor from DB
-    const STUDENT_ID = "b3a2f673-4411-41bd-bf4b-f31211d90050";
-    const SUBJECT_ID = "6f2302e2-11bc-4085-9447-31ff0e7c9cfd";
-    const TERM_ID = "eac3d662-5414-466a-ad92-297690f0f7f3";
+    const [me, setMe] = useState<AuthMe | null>(null);
+    const [subjects, setSubjects] = useState<SubjectSummary[]>([]);
+    const [terms, setTerms] = useState<TermSummary[]>([]);
+    const [students, setStudents] = useState<StudentSummary[]>([]);
+
+    const [selectedSubjectId, setSelectedSubjectId] = useState<string>('');
+    const [selectedTermId, setSelectedTermId] = useState<string>('');
+    const [selectedStudentId, setSelectedStudentId] = useState<string>('');
 
     const getTabStyle = (tabName: string) => ({
         padding: '0.75rem 1.5rem',
@@ -28,9 +34,99 @@ export default function TutorPage() {
         marginBottom: '-2px'
     });
 
+    const isTutor = (me?.role || '').toLowerCase() === 'tutor';
+    const tutorId = me?.tutor_id || '';
+
+    useEffect(() => {
+        const loadCatalog = async () => {
+            if (!isTutor) return;
+
+            const [subjectsData, termsData] = await Promise.all([
+                fetchSubjects(true),
+                fetchTerms(true),
+            ]);
+            setSubjects(subjectsData);
+            setTerms(termsData);
+
+            setSelectedSubjectId((prev) => prev || subjectsData[0]?.id || '');
+            setSelectedTermId((prev) => prev || termsData[0]?.id || '');
+        };
+
+        loadCatalog();
+    }, [isTutor]);
+
+    useEffect(() => {
+        const loadStudents = async () => {
+            if (!isTutor) return;
+            if (!selectedSubjectId) return;
+
+            const studentsData = await fetchStudents(true, selectedSubjectId);
+            setStudents(studentsData);
+            setSelectedStudentId((prev) => prev || studentsData[0]?.id || '');
+        };
+
+        loadStudents();
+    }, [isTutor, selectedSubjectId]);
+
     return (
         <div>
             <h2 style={{ marginBottom: '2rem', textAlign: 'center' }}>Panel del Tutor</h2>
+
+            <AuthPanel
+                title="Acceso Tutor"
+                defaultEmail="tutor@decies.com"
+                defaultPassword="decies"
+                onAuth={(loadedMe) => {
+                    setMe(loadedMe);
+                    setSelectedStudentId('');
+                }}
+                onLogout={() => {
+                    setMe(null);
+                    setSubjects([]);
+                    setTerms([]);
+                    setStudents([]);
+                    setSelectedSubjectId('');
+                    setSelectedTermId('');
+                    setSelectedStudentId('');
+                }}
+            />
+
+            {isTutor && (
+                <div className="card" style={{ marginBottom: '1.5rem' }}>
+                    <h3 style={{ marginBottom: '1rem' }}>Contexto</h3>
+                    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1rem' }}>
+                        <label>
+                            Asignatura
+                            <select className="input" value={selectedSubjectId} onChange={(e) => setSelectedSubjectId(e.target.value)}>
+                                {subjects.map((s) => (
+                                    <option key={s.id} value={s.id}>{s.name}</option>
+                                ))}
+                            </select>
+                        </label>
+                        <label>
+                            Trimestre
+                            <select className="input" value={selectedTermId} onChange={(e) => setSelectedTermId(e.target.value)}>
+                                {terms.map((t) => (
+                                    <option key={t.id} value={t.id}>{t.code} - {t.name}</option>
+                                ))}
+                            </select>
+                        </label>
+                        <label>
+                            Alumno
+                            <select className="input" value={selectedStudentId} onChange={(e) => setSelectedStudentId(e.target.value)}>
+                                {students.map((s) => (
+                                    <option key={s.id} value={s.id}>{s.full_name || s.email || s.id}</option>
+                                ))}
+                            </select>
+                        </label>
+                    </div>
+                    {(!selectedStudentId || !selectedSubjectId || !selectedTermId) && (
+                        <p style={{ marginTop: '0.75rem', color: 'var(--text-secondary)' }}>
+                            Selecciona asignatura, trimestre y alumno para ver métricas, recomendaciones e informes.
+                        </p>
+                    )}
+                </div>
+            )}
 
             {/* Tabs */}
             <div style={{ display: 'flex', gap: '1rem', marginBottom: '2rem', borderBottom: '2px solid var(--border-color)' }}>
@@ -64,38 +160,50 @@ export default function TutorPage() {
             {activeTab === 'content' && (
                 <div style={{ display: 'grid', gap: '2rem' }}>
                     <section>
-                        <UploadForm />
+                        <UploadForm tutorId={tutorId} subjectId={selectedSubjectId} termId={selectedTermId} />
                     </section>
                     <section>
-                        <UploadList />
+                        <UploadList tutorId={tutorId} />
                     </section>
                 </div>
             )}
 
             {activeTab === 'metrics' && (
-                <MetricsDashboard
-                    studentId={STUDENT_ID}
-                    subjectId={SUBJECT_ID}
-                    termId={TERM_ID}
-                />
+                selectedStudentId && selectedSubjectId && selectedTermId ? (
+                    <MetricsDashboard
+                        studentId={selectedStudentId}
+                        subjectId={selectedSubjectId}
+                        termId={selectedTermId}
+                    />
+                ) : (
+                    <p>Selecciona contexto para ver métricas.</p>
+                )
             )}
 
             {activeTab === 'recommendations' && (
-                <RecommendationList
-                    studentId={STUDENT_ID}
-                    subjectId={SUBJECT_ID}
-                    termId={TERM_ID}
-                    tutorId={TUTOR_ID}
-                />
+                selectedStudentId && selectedSubjectId && selectedTermId && tutorId ? (
+                    <RecommendationList
+                        studentId={selectedStudentId}
+                        subjectId={selectedSubjectId}
+                        termId={selectedTermId}
+                        tutorId={tutorId}
+                    />
+                ) : (
+                    <p>Selecciona contexto para ver recomendaciones.</p>
+                )
             )}
 
             {activeTab === 'reports' && (
-                <TutorReportPanel
-                    tutorId={TUTOR_ID}
-                    studentId={STUDENT_ID}
-                    subjectId={SUBJECT_ID}
-                    termId={TERM_ID}
-                />
+                selectedStudentId && selectedSubjectId && selectedTermId && tutorId ? (
+                    <TutorReportPanel
+                        tutorId={tutorId}
+                        studentId={selectedStudentId}
+                        subjectId={selectedSubjectId}
+                        termId={selectedTermId}
+                    />
+                ) : (
+                    <p>Selecciona contexto para ver informes.</p>
+                )
             )}
         </div>
     );

--- a/frontend/src/components/auth/AuthPanel.tsx
+++ b/frontend/src/components/auth/AuthPanel.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+import { AuthMe, clearAccessToken, fetchMe, getAccessToken, login, setAccessToken } from '../../services/auth';
+
+interface AuthPanelProps {
+    title?: string;
+    defaultEmail?: string;
+    defaultPassword?: string;
+    onAuth: (me: AuthMe) => void;
+    onLogout?: () => void;
+}
+
+export default function AuthPanel({ title = 'Acceso', defaultEmail = '', defaultPassword = '', onAuth, onLogout }: AuthPanelProps) {
+    const [email, setEmail] = useState(defaultEmail);
+    const [password, setPassword] = useState(defaultPassword);
+    const [me, setMe] = useState<AuthMe | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const init = async () => {
+            const token = getAccessToken();
+            if (!token) return;
+            try {
+                const loadedMe = await fetchMe();
+                setMe(loadedMe);
+                onAuth(loadedMe);
+            } catch {
+                clearAccessToken();
+            }
+        };
+        init();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleLogin = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError('');
+        setLoading(true);
+        try {
+            const token = await login(email, password);
+            setAccessToken(token);
+            const loadedMe = await fetchMe();
+            setMe(loadedMe);
+            onAuth(loadedMe);
+        } catch (err: any) {
+            const message = err.response?.data?.detail || err.message || 'Error de autenticación';
+            setError(message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleLogout = () => {
+        clearAccessToken();
+        setMe(null);
+        onLogout?.();
+    };
+
+    if (me) {
+        return (
+            <div className="card" style={{ marginBottom: '1.5rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem' }}>
+                    <div>
+                        <div style={{ fontWeight: 600 }}>{me.email}</div>
+                        <div style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
+                            Rol: {me.role || 'N/A'}
+                        </div>
+                    </div>
+                    <button className="btn btn-secondary" onClick={handleLogout}>
+                        Cerrar sesión
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="card" style={{ marginBottom: '1.5rem' }}>
+            <h3 style={{ marginBottom: '1rem' }}>{title}</h3>
+            <form onSubmit={handleLogin} style={{ display: 'grid', gap: '0.75rem' }}>
+                <label>
+                    Email
+                    <input className="input" value={email} onChange={(e) => setEmail(e.target.value)} />
+                </label>
+                <label>
+                    Password
+                    <input className="input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+                </label>
+                <button className="btn" disabled={loading}>
+                    {loading ? 'Entrando...' : 'Entrar'}
+                </button>
+                {error && <div style={{ color: 'var(--error)' }}>{error}</div>}
+            </form>
+        </div>
+    );
+}
+

--- a/frontend/src/components/tutor/UploadForm.tsx
+++ b/frontend/src/components/tutor/UploadForm.tsx
@@ -1,18 +1,28 @@
 "use client";
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import api from '../../services/api';
 
-export default function UploadForm() {
+interface UploadFormProps {
+    tutorId?: string;
+    subjectId?: string;
+    termId?: string;
+}
+
+export default function UploadForm({ tutorId: tutorIdProp = '', subjectId: subjectIdProp = '', termId: termIdProp = '' }: UploadFormProps) {
     const [file, setFile] = useState<File | null>(null);
     const [loading, setLoading] = useState(false);
     const [message, setMessage] = useState('');
 
     // Preliminary hardcoded IDs or inputs - For MVP Day 3 we assume user knows them or we default
     // Ideally these come from Auth context or Dropdowns
-    const [tutorId, setTutorId] = useState('');
-    const [subjectId, setSubjectId] = useState('');
-    const [termId, setTermId] = useState('');
+    const [tutorId, setTutorId] = useState(tutorIdProp);
+    const [subjectId, setSubjectId] = useState(subjectIdProp);
+    const [termId, setTermId] = useState(termIdProp);
+
+    useEffect(() => setTutorId(tutorIdProp), [tutorIdProp]);
+    useEffect(() => setSubjectId(subjectIdProp), [subjectIdProp]);
+    useEffect(() => setTermId(termIdProp), [termIdProp]);
 
     const handleUpload = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -31,10 +41,9 @@ export default function UploadForm() {
         formData.append('term_id', termId);
         // Defaults
         formData.append('upload_type', 'pdf');
-        formData.append('page_count', '1');
 
         try {
-            const res = await api.post('/content/uploads/', formData, {
+            const res = await api.post('/content/uploads', formData, {
                 headers: { 'Content-Type': 'multipart/form-data' }
             });
             setMessage(`Subida exitosa: ID ${res.data.id}`);
@@ -71,6 +80,7 @@ export default function UploadForm() {
                         onChange={e => setTutorId(e.target.value)}
                         placeholder="UUID..."
                         className="input"
+                        disabled={!!tutorIdProp}
                     />
                 </label>
 
@@ -82,6 +92,7 @@ export default function UploadForm() {
                         onChange={e => setSubjectId(e.target.value)}
                         placeholder="UUID..."
                         className="input"
+                        disabled={!!subjectIdProp}
                     />
                 </label>
 
@@ -93,6 +104,7 @@ export default function UploadForm() {
                         onChange={e => setTermId(e.target.value)}
                         placeholder="UUID..."
                         className="input"
+                        disabled={!!termIdProp}
                     />
                 </label>
 

--- a/frontend/src/components/tutor/UploadList.tsx
+++ b/frontend/src/components/tutor/UploadList.tsx
@@ -12,7 +12,11 @@ interface Upload {
     // Add other fields as needed
 }
 
-export default function UploadList() {
+interface UploadListProps {
+    tutorId?: string;
+}
+
+export default function UploadList({ tutorId }: UploadListProps) {
     const [uploads, setUploads] = useState<Upload[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
@@ -20,7 +24,7 @@ export default function UploadList() {
     const fetchUploads = async () => {
         try {
             setLoading(true);
-            const res = await api.get('/content/uploads');
+            const res = await api.get('/content/uploads', { params: { tutor_id: tutorId || undefined } });
             setUploads(res.data);
             setError('');
         } catch (err) {
@@ -33,7 +37,7 @@ export default function UploadList() {
 
     useEffect(() => {
         fetchUploads();
-    }, []);
+    }, [tutorId]);
 
     if (loading) return <p>Cargando uploads...</p>;
     if (error) return <p style={{ color: 'var(--error)' }}>{error}</p>;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,10 +1,23 @@
 import axios from 'axios';
 
+export const ACCESS_TOKEN_STORAGE_KEY = 'decies.access_token';
+
 const api = axios.create({
     baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1',
     headers: {
         'Content-Type': 'application/json',
     },
+});
+
+api.interceptors.request.use((config) => {
+    if (typeof window !== 'undefined') {
+        const token = window.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+        if (token) {
+            config.headers = config.headers ?? {};
+            config.headers.Authorization = `Bearer ${token}`;
+        }
+    }
+    return config;
 });
 
 export default api;

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import api, { ACCESS_TOKEN_STORAGE_KEY } from './api';
+
+export interface AuthMe {
+    id: string;
+    email: string;
+    full_name?: string | null;
+    role?: string | null;
+    tutor_id?: string | null;
+    student_id?: string | null;
+}
+
+export function getAccessToken(): string | null {
+    if (typeof window === 'undefined') return null;
+    return window.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+}
+
+export function setAccessToken(token: string) {
+    window.localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, token);
+}
+
+export function clearAccessToken() {
+    window.localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+}
+
+export async function login(email: string, password: string): Promise<string> {
+    const res = await api.post('/login/access-token', { email, password });
+    return res.data.access_token as string;
+}
+
+export async function fetchMe(): Promise<AuthMe> {
+    const res = await api.get('/auth/me');
+    return res.data as AuthMe;
+}
+

--- a/frontend/src/services/catalog.ts
+++ b/frontend/src/services/catalog.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import api from './api';
+
+export interface SubjectSummary {
+    id: string;
+    name: string;
+    description?: string | null;
+}
+
+export interface TermSummary {
+    id: string;
+    code: string;
+    name: string;
+    status: string;
+}
+
+export interface StudentSummary {
+    id: string;
+    user_id?: string | null;
+    subject_id?: string | null;
+    email?: string | null;
+    full_name?: string | null;
+}
+
+export async function fetchSubjects(mine = true): Promise<SubjectSummary[]> {
+    const res = await api.get('/catalog/subjects', { params: { mine } });
+    return res.data as SubjectSummary[];
+}
+
+export async function fetchTerms(active: boolean | null = true): Promise<TermSummary[]> {
+    const res = await api.get('/catalog/terms', { params: { active } });
+    return res.data as TermSummary[];
+}
+
+export async function fetchStudents(mine = true, subjectId?: string): Promise<StudentSummary[]> {
+    const res = await api.get('/catalog/students', {
+        params: { mine, subject_id: subjectId },
+    });
+    return res.data as StudentSummary[];
+}
+


### PR DESCRIPTION
## Qu?
- Backend: `GET /api/v1/auth/me` + endpoints `GET /api/v1/catalog/*` para cargar contexto (asignaturas, trimestres, alumnos).
- Seed: passwords bcrypt para `tutor@decies.com` y `student@decies.com` + v?nculo del alumno a la asignatura.
- Frontend: elimina UUIDs hardcodeados; login simple y selector de contexto en `/tutor` y `/student`.

## C?mo probar
- En `/tutor` inicia sesi?n con `tutor@decies.com` / `decies`, elige contexto y usa tabs.
- En `/student` inicia sesi?n con `student@decies.com` / `decies` y lanza una actividad.

## Checks
- Backend CI (ruff + pytest)
- Frontend CI (lint + build)
