### PR TITLE
feat(reports): browse reports list and detail

### DIFF
--- a/backend/app/routers/reports.py
+++ b/backend/app/routers/reports.py
@@ -2,14 +2,15 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.db import get_db
+from app.models.report import TutorReport
 from app.models.student import Student
 from app.models.subject import Subject
 from app.models.term import Term
 from app.models.tutor import Tutor
-from app.schemas.report import TutorReportResponse
+from app.schemas.report import TutorReportListItemResponse, TutorReportResponse
 from app.services.report_service import report_service
 
 router = APIRouter(prefix="/reports", tags=["reports"])
@@ -85,4 +86,54 @@ def get_latest_student_report(
 
     if not report:
         raise HTTPException(status_code=404, detail="No report found")
+    return report
+
+
+@router.get("", response_model=list[TutorReportListItemResponse])
+def list_reports(
+    tutor_id: uuid.UUID,
+    student_id: uuid.UUID | None = None,
+    subject_id: uuid.UUID | None = None,
+    term_id: uuid.UUID | None = None,
+    limit: int = 20,
+    db: Session = Depends(get_db),
+):
+    query = db.query(TutorReport).filter(TutorReport.tutor_id == tutor_id)
+    if student_id:
+        query = query.filter(TutorReport.student_id == student_id)
+    if subject_id:
+        query = query.filter(TutorReport.subject_id == subject_id)
+    if term_id:
+        query = query.filter(TutorReport.term_id == term_id)
+
+    try:
+        return query.order_by(TutorReport.generated_at.desc()).limit(limit).all()
+    except SQLAlchemyError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error listing reports.",
+        ) from exc
+
+
+@router.get("/{report_id}", response_model=TutorReportResponse)
+def get_report(
+    report_id: uuid.UUID,
+    tutor_id: uuid.UUID,
+    db: Session = Depends(get_db),
+):
+    try:
+        report = (
+            db.query(TutorReport)
+            .options(selectinload(TutorReport.sections))
+            .filter(TutorReport.id == report_id, TutorReport.tutor_id == tutor_id)
+            .first()
+        )
+    except SQLAlchemyError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Database error reading report.",
+        ) from exc
+
+    if not report:
+        raise HTTPException(status_code=404, detail="Report not found")
     return report

--- a/backend/app/schemas/report.py
+++ b/backend/app/schemas/report.py
@@ -31,3 +31,15 @@ class TutorReportResponse(BaseModel):
     sections: list[TutorReportSectionResponse] = []
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class TutorReportListItemResponse(BaseModel):
+    id: uuid.UUID
+    tutor_id: uuid.UUID
+    student_id: uuid.UUID
+    subject_id: uuid.UUID
+    term_id: uuid.UUID
+    summary: str
+    generated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -131,3 +131,25 @@ def test_generate_and_get_latest_report(db_session: Session):
     assert latest["id"] == payload["id"]
     assert any(s["section_type"] == "executive_summary" for s in latest["sections"])
     assert any(s["section_type"] == "recommendations" for s in latest["sections"])
+
+    list_res = client.get(
+        "/api/v1/reports",
+        params={
+            "tutor_id": str(tutor.id),
+            "student_id": str(student.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "limit": 10,
+        },
+    )
+    assert list_res.status_code == 200
+    reports = list_res.json()
+    assert any(r["id"] == payload["id"] for r in reports)
+
+    get_res = client.get(
+        f"/api/v1/reports/{payload['id']}",
+        params={"tutor_id": str(tutor.id)},
+    )
+    assert get_res.status_code == 200
+    report = get_res.json()
+    assert report["id"] == payload["id"]


### PR DESCRIPTION
## Qu?
- Backend: completa API de informes con `GET /api/v1/reports` y `GET /api/v1/reports/{id}`.
- Tests: ampl?a `backend/tests/test_reports.py` para cubrir list/get.

## Por qu?
- Doc 23 (Sprint 1 D?a 6) menciona endpoints de consulta adicionales para navegar informes.
