### PR TITLE
feat(rbac): harden context and access control

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -7,6 +7,9 @@ from sqlalchemy.orm import Session
 from app.core import security
 from app.core.config import settings
 from app.core.db import get_db
+from app.models.role import Role
+from app.models.student import Student
+from app.models.tutor import Tutor
 from app.models.user import User
 from app.schemas.auth import TokenPayload
 
@@ -36,3 +39,43 @@ def get_current_active_user(
     if not current_user.is_active:
         raise HTTPException(status_code=400, detail="Inactive user")
     return current_user
+
+
+def get_current_role_name(db: Session, user: User) -> str:
+    if not user.role_id:
+        return ""
+    role = db.get(Role, user.role_id)
+    return (role.name if role else "").casefold()
+
+
+def require_roles(db: Session, user: User, allowed: set[str]) -> str:
+    role_name = get_current_role_name(db, user)
+    if role_name not in {r.casefold() for r in allowed}:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions")
+    return role_name
+
+
+def get_current_tutor(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> Tutor:
+    require_roles(db, current_user, {"tutor"})
+    tutor = db.query(Tutor).filter(Tutor.user_id == current_user.id).first()
+    if not tutor:
+        raise HTTPException(status_code=404, detail="Tutor not found")
+    return tutor
+
+
+def get_current_student(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> Student:
+    require_roles(db, current_user, {"student"})
+    student = (
+        db.query(Student)
+        .filter((Student.user_id == current_user.id) | (Student.id == current_user.id))
+        .first()
+    )
+    if not student:
+        raise HTTPException(status_code=404, detail="Student not found")
+    return student

--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -4,8 +4,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.db import get_db
+from app.core.deps import get_current_active_user, get_current_role_name, get_current_student
 from app.models.metric import MasteryState, MetricAggregate
 from app.models.microconcept import MicroConcept
+from app.models.subject import Subject
+from app.models.user import User
 from app.schemas.metric import (
     MasteryStateSummary,
     StudentMetricsSummary,
@@ -21,10 +24,25 @@ def get_student_metrics(
     subject_id: uuid.UUID,
     term_id: uuid.UUID,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     Get aggregated metrics for a student in a subject/term.
     """
+    role_name = get_current_role_name(db, current_user)
+    if role_name == "student":
+        student = get_current_student(db=db, current_user=current_user)
+        if student_id != student.id:
+            raise HTTPException(status_code=403, detail="Not allowed")
+        if student.subject_id and student.subject_id != subject_id:
+            raise HTTPException(status_code=403, detail="Not allowed")
+    elif role_name == "tutor":
+        subject = db.get(Subject, subject_id)
+        if subject and subject.tutor_id and subject.tutor_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Not allowed")
+    else:
+        raise HTTPException(status_code=403, detail="Role not allowed")
+
     # Get latest metric aggregate
     metric = (
         db.query(MetricAggregate)
@@ -87,10 +105,25 @@ def get_student_mastery(
     subject_id: uuid.UUID,
     term_id: uuid.UUID,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     Get mastery states for all microconcepts for a student.
     """
+    role_name = get_current_role_name(db, current_user)
+    if role_name == "student":
+        student = get_current_student(db=db, current_user=current_user)
+        if student_id != student.id:
+            raise HTTPException(status_code=403, detail="Not allowed")
+        if student.subject_id and student.subject_id != subject_id:
+            raise HTTPException(status_code=403, detail="Not allowed")
+    elif role_name == "tutor":
+        subject = db.get(Subject, subject_id)
+        if subject and subject.tutor_id and subject.tutor_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Not allowed")
+    else:
+        raise HTTPException(status_code=403, detail="Role not allowed")
+
     # Get mastery states
     mastery_states = (
         db.query(MasteryState)
@@ -152,10 +185,18 @@ def recalculate_metrics(
     subject_id: uuid.UUID,
     term_id: uuid.UUID,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     Manually trigger metrics recalculation (admin/debug endpoint).
     """
+    role_name = get_current_role_name(db, current_user)
+    if role_name != "tutor":
+        raise HTTPException(status_code=403, detail="Role not allowed")
+    subject = db.get(Subject, subject_id)
+    if subject and subject.tutor_id and subject.tutor_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+
     try:
         metrics, mastery_states = metric_service.recalculate_and_save_metrics(
             db, student_id, subject_id, term_id

--- a/backend/app/routers/recommendations.py
+++ b/backend/app/routers/recommendations.py
@@ -5,9 +5,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.db import get_db
+from app.core.deps import get_current_active_user, get_current_role_name, get_current_tutor
 from app.models.recommendation import RecommendationInstance
 from app.models.student import Student
-from app.models.tutor import Tutor
+from app.models.subject import Subject
+from app.models.user import User
 from app.schemas.recommendation import (
     RecommendationInstanceResponse,
     TutorDecisionCreate,
@@ -29,14 +31,26 @@ def get_student_recommendations(
     status_filter: str = "pending",  # pending, accepted, rejected, all
     generate: bool = True,  # If true, run generation logic
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     Get recommendations for a student.
     By default runs generation logic to find new recommendations based on latest metrics.
     """
-    student = db.query(Student).get(student_id)
+    role_name = get_current_role_name(db, current_user)
+    if role_name != "tutor":
+        raise HTTPException(status_code=403, detail="Role not allowed")
+    get_current_tutor(db=db, current_user=current_user)
+
+    subject = db.get(Subject, subject_id)
+    if subject and subject.tutor_id and subject.tutor_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+
+    student = db.get(Student, student_id)
     if not student:
         raise HTTPException(status_code=404, detail="Student not found")
+    if student.subject_id and student.subject_id != subject_id:
+        raise HTTPException(status_code=403, detail="Not allowed")
 
     if generate:
         # Run generation logic
@@ -55,24 +69,52 @@ def get_student_recommendations(
 
 
 @router.get("/{recommendation_id}", response_model=RecommendationInstanceResponse)
-def get_recommendation(recommendation_id: uuid.UUID, db: Session = Depends(get_db)):
-    rec = db.query(RecommendationInstance).get(recommendation_id)
+def get_recommendation(
+    recommendation_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    role_name = get_current_role_name(db, current_user)
+    if role_name != "tutor":
+        raise HTTPException(status_code=403, detail="Role not allowed")
+
+    rec = db.get(RecommendationInstance, recommendation_id)
     if not rec:
         raise HTTPException(status_code=404, detail="Recommendation not found")
+
+    student = db.get(Student, rec.student_id)
+    if student and student.subject_id:
+        subject = db.get(Subject, student.subject_id)
+        if subject and subject.tutor_id and subject.tutor_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Not allowed")
     return rec
 
 
 @router.post("/{recommendation_id}/decision", response_model=TutorDecisionResponse)
 def make_tutor_decision(
-    recommendation_id: uuid.UUID, decision: TutorDecisionCreate, db: Session = Depends(get_db)
+    recommendation_id: uuid.UUID,
+    decision: TutorDecisionCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     Record tutor decision (accept/reject) on a recommendation.
     """
-    # Verify tutor exists
-    tutor = db.query(Tutor).get(decision.tutor_id)
-    if not tutor:
-        raise HTTPException(status_code=404, detail="Tutor not found")
+    role_name = get_current_role_name(db, current_user)
+    if role_name != "tutor":
+        raise HTTPException(status_code=403, detail="Role not allowed")
+    tutor = get_current_tutor(db=db, current_user=current_user)
+    if decision.tutor_id != tutor.id:
+        raise HTTPException(status_code=403, detail="Tutor mismatch")
+
+    rec = db.get(RecommendationInstance, recommendation_id)
+    if not rec:
+        raise HTTPException(status_code=404, detail="Recommendation not found")
+    student = db.get(Student, rec.student_id)
+    if student and student.subject_id:
+        subject = db.get(Subject, student.subject_id)
+        if subject and subject.tutor_id and subject.tutor_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Not allowed")
 
     try:
         if decision.recommendation_id != recommendation_id:


### PR DESCRIPTION
Implements Sprint 2 Day 1 (Issue #26): require auth + enforce tutor/student ownership checks across content, activity, metrics, recommendations, and reports endpoints.

- Adds role helpers and tutor/student deps
- Updates API tests to login and use Bearer tokens
- Backend: ruff + pytest green (via scripts/ps/test-backend.ps1)