### PR TITLE
feat(llm): add E3 microconcept mapping

### DIFF
--- a/backend/alembic/versions/749cf271a66c_add_e3_mapping.py
+++ b/backend/alembic/versions/749cf271a66c_add_e3_mapping.py
@@ -1,0 +1,51 @@
+"""add e3 mapping
+
+Revision ID: 749cf271a66c
+Revises: 6d2f0c3c1a7b
+Create Date: 2025-12-18 00:17:02.790536
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "749cf271a66c"
+down_revision: str | None = "6d2f0c3c1a7b"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TYPE llm_run_step ADD VALUE 'E3_MAP';
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+    op.add_column(
+        "knowledge_chunks",
+        sa.Column("microconcept_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "knowledge_chunks_microconcept_id_fkey",
+        "knowledge_chunks",
+        "microconcepts",
+        ["microconcept_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "knowledge_chunks_microconcept_id_fkey", "knowledge_chunks", type_="foreignkey"
+    )
+    op.drop_column("knowledge_chunks", "microconcept_id")

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -41,6 +41,11 @@ class KnowledgeChunk(Base):
         ),
         nullable=False,
     )
+    microconcept_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("microconcepts.id", name="knowledge_chunks_microconcept_id_fkey"),
+        nullable=True,
+    )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     index: Mapped[int] = mapped_column(nullable=False, default=0)
     embedding_id: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/app/models/llm_run.py
+++ b/backend/app/models/llm_run.py
@@ -11,6 +11,7 @@ from app.core.db import Base
 
 class LLMRunStep(str, enum.Enum):
     E2_STRUCTURE = "E2_STRUCTURE"
+    E3_MAP = "E3_MAP"
     E4_ITEMS = "E4_ITEMS"
 
 

--- a/backend/tests/e2e/test_e2e_01_flow.py
+++ b/backend/tests/e2e/test_e2e_01_flow.py
@@ -24,6 +24,31 @@ client = TestClient(app)
 
 MOCK_PDF_TEXT = "Contenido de prueba de matemáticas: suma, resta y números enteros."
 MOCK_E2_RESPONSE = {"summary": "Resumen", "chunks": ["Chunk 1", "Chunk 2"]}
+MOCK_E3_RESPONSE = {
+    "chunk_mappings": [
+        {
+            "chunk_index": 0,
+            "microconcept_match": {
+                "microconcept_id": None,
+                "microconcept_code": None,
+                "microconcept_name": None,
+            },
+            "confidence": 0.0,
+            "reason": "low confidence",
+        },
+        {
+            "chunk_index": 1,
+            "microconcept_match": {
+                "microconcept_id": None,
+                "microconcept_code": None,
+                "microconcept_name": None,
+            },
+            "confidence": 0.0,
+            "reason": "low confidence",
+        },
+    ],
+    "quality": {"mapping_coverage": 0.0, "mapping_precision_hint": "low", "notes": ["n/a"]},
+}
 MOCK_E4_RESPONSE = {
     "items": [
         {
@@ -150,6 +175,7 @@ def test_e2e_01_flow_content_to_report(db_session: Session):
         mock_instance = mock_openai.return_value
         mock_instance.chat.completions.create.side_effect = [
             _create_mock_response(MOCK_E2_RESPONSE),
+            _create_mock_response(MOCK_E3_RESPONSE),
             _create_mock_response(MOCK_E4_RESPONSE),
             _create_mock_response(MOCK_E4_RESPONSE),
         ]


### PR DESCRIPTION
Sprint 2 Day 2 (Issue #27): implement E3 mapping step to assign chunks/items to existing microconcepts.

- Adds E3 LLM step + models and persists mapping to knowledge_chunks.microconcept_id
- Extends LLM run tracking with E3_MAP
- Updates pipeline/tests mocks so CI remains deterministic