### PR TITLE
feat(llm): add E5 item validation

### DIFF
--- a/backend/alembic/versions/6053b2dd2b53_add_e5_item_validation.py
+++ b/backend/alembic/versions/6053b2dd2b53_add_e5_item_validation.py
@@ -1,0 +1,48 @@
+"""add e5 item validation
+
+Revision ID: 6053b2dd2b53
+Revises: 749cf271a66c
+Create Date: 2025-12-18 00:30:44.295888
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "6053b2dd2b53"
+down_revision: str | None = "749cf271a66c"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TYPE llm_run_step ADD VALUE 'E5_VALIDATE';
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+    op.add_column(
+        "items",
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+    )
+    op.add_column("items", sa.Column("source_chunk_index", sa.Integer(), nullable=True))
+    op.add_column("items", sa.Column("validation_status", sa.String(length=20), nullable=True))
+    op.add_column("items", sa.Column("validation_reason", sa.Text(), nullable=True))
+
+    op.alter_column("items", "is_active", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("items", "validation_reason")
+    op.drop_column("items", "validation_status")
+    op.drop_column("items", "source_chunk_index")
+    op.drop_column("items", "is_active")

--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Text, text
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -36,6 +36,10 @@ class Item(Base):
     correct_answer: Mapped[str] = mapped_column(Text, nullable=False)
     explanation: Mapped[str | None] = mapped_column(Text, nullable=True)
     difficulty: Mapped[int] = mapped_column(default=1)  # 1-3?
+    source_chunk_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    validation_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    validation_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=True
     )

--- a/backend/app/models/llm_run.py
+++ b/backend/app/models/llm_run.py
@@ -13,6 +13,7 @@ class LLMRunStep(str, enum.Enum):
     E2_STRUCTURE = "E2_STRUCTURE"
     E3_MAP = "E3_MAP"
     E4_ITEMS = "E4_ITEMS"
+    E5_VALIDATE = "E5_VALIDATE"
 
 
 class LLMRun(Base):

--- a/backend/app/routers/activity.py
+++ b/backend/app/routers/activity.py
@@ -99,6 +99,7 @@ def create_session(
         db.query(Item)
         .join(ContentUpload, Item.content_upload_id == ContentUpload.id)
         .filter(
+            Item.is_active.is_(True),
             ContentUpload.subject_id == session_data.subject_id,
             ContentUpload.term_id == session_data.term_id,
         )

--- a/backend/app/routers/content.py
+++ b/backend/app/routers/content.py
@@ -178,5 +178,12 @@ def get_upload_items(
     else:
         raise HTTPException(status_code=403, detail="Role not allowed")
 
-    items = db.query(Item).filter(Item.content_upload_id == upload_id).all()
+    items = (
+        db.query(Item)
+        .filter(
+            Item.content_upload_id == upload_id,
+            Item.is_active.is_(True),
+        )
+        .all()
+    )
     return items

--- a/backend/tests/e2e/test_e2e_01_flow.py
+++ b/backend/tests/e2e/test_e2e_01_flow.py
@@ -49,6 +49,49 @@ MOCK_E3_RESPONSE = {
     ],
     "quality": {"mapping_coverage": 0.0, "mapping_precision_hint": "low", "notes": ["n/a"]},
 }
+MOCK_E5_RESPONSE = {
+    "validated_items": [
+        {
+            "index": 0,
+            "status": "ok",
+            "reason": "ok",
+            "item": {
+                "item_type": "mcq",
+                "stem": "¿Cuál es el resultado de 1+1?",
+                "options": ["1", "2", "3", "4"],
+                "correct_answer": "2",
+                "explanation": "1+1=2.",
+                "difficulty": 1.0,
+                "microconcept_ref": {
+                    "microconcept_id": None,
+                    "microconcept_code": None,
+                    "microconcept_name": None,
+                },
+                "source_chunk_index": 0,
+            },
+        },
+        {
+            "index": 1,
+            "status": "ok",
+            "reason": "ok",
+            "item": {
+                "item_type": "mcq",
+                "stem": "¿Cuál es el resultado de 1+1?",
+                "options": ["1", "2", "3", "4"],
+                "correct_answer": "2",
+                "explanation": "1+1=2.",
+                "difficulty": 1.0,
+                "microconcept_ref": {
+                    "microconcept_id": None,
+                    "microconcept_code": None,
+                    "microconcept_name": None,
+                },
+                "source_chunk_index": 1,
+            },
+        },
+    ],
+    "quality": {"kept": 2, "fixed": 0, "dropped": 0, "notes": ["ok"]},
+}
 MOCK_E4_RESPONSE = {
     "items": [
         {
@@ -178,6 +221,7 @@ def test_e2e_01_flow_content_to_report(db_session: Session):
             _create_mock_response(MOCK_E3_RESPONSE),
             _create_mock_response(MOCK_E4_RESPONSE),
             _create_mock_response(MOCK_E4_RESPONSE),
+            _create_mock_response(MOCK_E5_RESPONSE),
         ]
 
         process_res = client.post(

--- a/backend/tests/test_llm_pipeline.py
+++ b/backend/tests/test_llm_pipeline.py
@@ -41,6 +41,10 @@ MOCK_E3_RESPONSE_BASE = {
     "chunk_mappings": [],
     "quality": {"mapping_coverage": 1.0, "mapping_precision_hint": "high", "notes": ["ok"]},
 }
+MOCK_E5_RESPONSE_BASE = {
+    "validated_items": [],
+    "quality": {"kept": 0, "fixed": 0, "dropped": 0, "notes": ["ok"]},
+}
 
 
 @pytest.fixture
@@ -191,6 +195,52 @@ def test_process_pipeline_success(db_session):
             create_mock_response(mock_e3_response),  # E3
             create_mock_response(MOCK_E4_RESPONSE),  # E4 for Chunk 1
             create_mock_response(MOCK_E4_RESPONSE),  # E4 for Chunk 2
+            create_mock_response(
+                {
+                    **MOCK_E5_RESPONSE_BASE,
+                    "validated_items": [
+                        {
+                            "index": 0,
+                            "status": "ok",
+                            "reason": "ok",
+                            "item": {
+                                "item_type": "mcq",
+                                "stem": "What is fun?",
+                                "options": ["Algebra", "Nothing"],
+                                "correct_answer": "Algebra",
+                                "explanation": "Because it is.",
+                                "difficulty": 1.0,
+                                "microconcept_ref": {
+                                    "microconcept_id": str(mc_1.id),
+                                    "microconcept_code": mc_1.code,
+                                    "microconcept_name": mc_1.name,
+                                },
+                                "source_chunk_index": 0,
+                            },
+                        },
+                        {
+                            "index": 1,
+                            "status": "ok",
+                            "reason": "ok",
+                            "item": {
+                                "item_type": "mcq",
+                                "stem": "What is fun?",
+                                "options": ["Algebra", "Nothing"],
+                                "correct_answer": "Algebra",
+                                "explanation": "Because it is.",
+                                "difficulty": 1.0,
+                                "microconcept_ref": {
+                                    "microconcept_id": str(mc_2.id),
+                                    "microconcept_code": mc_2.code,
+                                    "microconcept_name": mc_2.name,
+                                },
+                                "source_chunk_index": 1,
+                            },
+                        },
+                    ],
+                    "quality": {"kept": 2, "fixed": 0, "dropped": 0, "notes": ["ok"]},
+                }
+            ),  # E5
         ]
 
         # 3. Trigger Endpoint


### PR DESCRIPTION
Sprint 2 Day 3 (Issue #28): add E5 validation step to filter/fix/drop generated items with minimal traceability.

- Adds item fields: is_active, source_chunk_index, validation_status, validation_reason
- Adds LLM step E5_VALIDATE and runs it after E4; only active items are served/used for sessions
- Updates mocks/tests so CI remains deterministic (includes E5)