### PR TITLE
feat(activity): add MATCH game

### DIFF
--- a/backend/alembic/versions/9a31fa56887f_add_match_item_type.py
+++ b/backend/alembic/versions/9a31fa56887f_add_match_item_type.py
@@ -1,0 +1,36 @@
+"""add match item type
+
+Revision ID: 9a31fa56887f
+Revises: 6053b2dd2b53
+Create Date: 2025-12-18 19:30:43.881659
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "9a31fa56887f"
+down_revision: str | None = "6053b2dd2b53"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TYPE item_type ADD VALUE 'match';
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Enum values can't be removed easily in Postgres; no-op.
+    return None

--- a/backend/alembic/versions/9a31fa56887f_add_match_item_type.py
+++ b/backend/alembic/versions/9a31fa56887f_add_match_item_type.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
         """
         DO $$
         BEGIN
-            ALTER TYPE item_type ADD VALUE 'match';
+            ALTER TYPE item_type ADD VALUE 'MATCH';
         EXCEPTION
             WHEN duplicate_object THEN NULL;
         END $$;

--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -12,6 +12,7 @@ from app.core.db import Base
 class ItemType(str, enum.Enum):
     MCQ = "multiple_choice"
     TRUE_FALSE = "true_false"
+    MATCH = "match"
 
 
 class Item(Base):

--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -33,6 +33,7 @@ class ActivitySessionBase(BaseModel):
 
 class ActivitySessionCreate(ActivitySessionBase):
     item_count: int = 10  # Number of items to include in session
+    content_upload_id: uuid.UUID | None = None
 
 
 class ActivitySessionResponse(ActivitySessionBase):

--- a/backend/app/schemas/item.py
+++ b/backend/app/schemas/item.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import List, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -9,7 +9,7 @@ from app.models.item import ItemType
 class ItemBase(BaseModel):
     type: ItemType
     stem: str
-    options: Optional[List[str]] = None
+    options: Any | None = None
     # correct_answer should be hidden potentially if we want server-side grading
     # But for MVP immediate feedback:
     correct_answer: str

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 import uuid
@@ -270,7 +271,7 @@ def seed_db():
                     microconcept_id=first_mc.id if first_mc else None,
                     type=ItemType.MCQ,
                     stem=f"Pregunta de prueba {i + 1}",
-                    options={"choices": ["Opción A", "Opción B", "Opción C", "Opción D"]},
+                    options=["Opción A", "Opción B", "Opción C", "Opción D"],
                     correct_answer="Opción A",
                     explanation=f"Explicación de la pregunta {i + 1}",
                     difficulty=1,
@@ -278,7 +279,67 @@ def seed_db():
                 db.add(item)
                 logger.info(f"Created test Item {i + 1}")
 
+            match_mcs = (
+                db.query(MicroConcept)
+                .filter(MicroConcept.subject_id == subject.id, MicroConcept.term_id == term.id)
+                .order_by(MicroConcept.code.asc())
+                .limit(4)
+                .all()
+            )
+            if len(match_mcs) == 4:
+                pairs = [{"left": mc.name, "right": mc.description or mc.name} for mc in match_mcs]
+                correct_map = {p["left"]: p["right"] for p in pairs}
+                match_item = Item(
+                    id=uuid.uuid4(),
+                    content_upload_id=test_upload.id,
+                    microconcept_id=match_mcs[0].id,
+                    type=ItemType.MATCH,
+                    stem="Empareja cada microconcepto con su descripción",
+                    options={"pairs": pairs},
+                    correct_answer=json.dumps(correct_map, ensure_ascii=False),
+                    explanation="",
+                    difficulty=1,
+                )
+                db.add(match_item)
+                logger.info("Created test MATCH Item")
+
             db.commit()
+        else:
+            existing_match = (
+                db.query(Item)
+                .filter(
+                    Item.content_upload_id == test_upload.id,
+                    Item.type == ItemType.MATCH,
+                )
+                .first()
+            )
+            if not existing_match:
+                match_mcs = (
+                    db.query(MicroConcept)
+                    .filter(MicroConcept.subject_id == subject.id, MicroConcept.term_id == term.id)
+                    .order_by(MicroConcept.code.asc())
+                    .limit(4)
+                    .all()
+                )
+                if len(match_mcs) == 4:
+                    pairs = [
+                        {"left": mc.name, "right": mc.description or mc.name} for mc in match_mcs
+                    ]
+                    correct_map = {p["left"]: p["right"] for p in pairs}
+                    match_item = Item(
+                        id=uuid.uuid4(),
+                        content_upload_id=test_upload.id,
+                        microconcept_id=match_mcs[0].id,
+                        type=ItemType.MATCH,
+                        stem="Empareja cada microconcepto con su descripción",
+                        options={"pairs": pairs},
+                        correct_answer=json.dumps(correct_map, ensure_ascii=False),
+                        explanation="",
+                        difficulty=1,
+                    )
+                    db.add(match_item)
+                    db.commit()
+                    logger.info("Created missing test MATCH Item")
 
         logger.info("Seeding complete!")
         logger.info(f"Tutor User ID: {user_tutor.id}")

--- a/frontend/src/app/student/page.tsx
+++ b/frontend/src/app/student/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import AuthPanel from '../../components/auth/AuthPanel';
 import api from '../../services/api';
 import QuizRunner from '../../components/student/QuizRunner';
+import MatchRunner from '../../components/student/MatchRunner';
 import { AuthMe } from '../../services/auth';
 
 interface Upload {
@@ -18,6 +19,7 @@ export default function StudentPage() {
     const [uploads, setUploads] = useState<Upload[]>([]);
     const [loading, setLoading] = useState(true);
     const [selectedUpload, setSelectedUpload] = useState<Upload | null>(null);
+    const [selectedMode, setSelectedMode] = useState<'QUIZ' | 'MATCH'>('QUIZ');
     const [me, setMe] = useState<AuthMe | null>(null);
 
     useEffect(() => {
@@ -40,7 +42,15 @@ export default function StudentPage() {
         if (!studentId) {
             return <p>No hay estudiante asociado a esta sesión. Inicia sesión como estudiante.</p>;
         }
-        return (
+        return selectedMode === 'MATCH' ? (
+            <MatchRunner
+                uploadId={selectedUpload.id}
+                studentId={studentId}
+                subjectId={selectedUpload.subject_id}
+                termId={selectedUpload.term_id}
+                onExit={() => setSelectedUpload(null)}
+            />
+        ) : (
             <QuizRunner
                 uploadId={selectedUpload.id}
                 studentId={studentId}
@@ -71,13 +81,22 @@ export default function StudentPage() {
                             <p style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>
                                 {new Date(upload.created_at).toLocaleDateString()}
                             </p>
-                            <button
-                                disabled={!studentId}
-                                onClick={() => setSelectedUpload(upload)}
-                                className="btn"
-                            >
-                                Comenzar Actividad
-                            </button>
+                            <div style={{ display: 'flex', gap: '0.75rem' }}>
+                                <button
+                                    disabled={!studentId}
+                                    onClick={() => { setSelectedMode('QUIZ'); setSelectedUpload(upload); }}
+                                    className="btn"
+                                >
+                                    Quiz
+                                </button>
+                                <button
+                                    disabled={!studentId}
+                                    onClick={() => { setSelectedMode('MATCH'); setSelectedUpload(upload); }}
+                                    className="btn btn-secondary"
+                                >
+                                    Match
+                                </button>
+                            </div>
                         </div>
                     ))}
                     {uploads.length === 0 && <p>No hay actividades asignadas.</p>}

--- a/frontend/src/components/student/MatchRunner.tsx
+++ b/frontend/src/components/student/MatchRunner.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { Fragment, useEffect, useMemo, useState } from "react";
+import api from "../../services/api";
+
+type MatchPair = { left: string; right: string };
+
+interface Item {
+    id: string;
+    type: string;
+    stem: string;
+    options?: any;
+    correct_answer: string;
+    explanation?: string;
+}
+
+interface MatchRunnerProps {
+    uploadId: string;
+    studentId: string;
+    subjectId: string;
+    termId: string;
+    onExit: () => void;
+}
+
+function getPairs(item: Item): MatchPair[] {
+    const pairs = item.options?.pairs;
+    if (!Array.isArray(pairs)) return [];
+    return pairs
+        .filter((p) => p && typeof p.left === "string" && typeof p.right === "string")
+        .map((p) => ({ left: p.left, right: p.right }));
+}
+
+function shuffle<T>(arr: T[]): T[] {
+    const copy = [...arr];
+    for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy;
+}
+
+export default function MatchRunner({ uploadId, studentId, subjectId, termId, onExit }: MatchRunnerProps) {
+    const [items, setItems] = useState<Item[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [sessionId, setSessionId] = useState<string | null>(null);
+    const [activityTypeId, setActivityTypeId] = useState<string | null>(null);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [finished, setFinished] = useState(false);
+    const [assignments, setAssignments] = useState<Record<string, string>>({});
+    const [feedback, setFeedback] = useState<{ isCorrect: boolean; text: string } | null>(null);
+    const [questionStartTime, setQuestionStartTime] = useState<Date>(new Date());
+
+    useEffect(() => {
+        const initSession = async () => {
+            try {
+                const typesRes = await api.get("/activities/activity-types");
+                const matchType = typesRes.data.find((t: any) => t.code === "MATCH");
+                if (!matchType) {
+                    console.error("MATCH activity type not found");
+                    setLoading(false);
+                    return;
+                }
+                setActivityTypeId(matchType.id);
+
+                const sessionRes = await api.post("/activities/sessions", {
+                    student_id: studentId,
+                    activity_type_id: matchType.id,
+                    subject_id: subjectId,
+                    term_id: termId,
+                    topic_id: null,
+                    item_count: 5,
+                    content_upload_id: uploadId,
+                    device_type: "web",
+                });
+                const sid = sessionRes.data.id;
+                setSessionId(sid);
+
+                const itemsRes = await api.get(`/activities/sessions/${sid}/items`);
+                setItems(itemsRes.data);
+
+                setQuestionStartTime(new Date());
+            } catch (err: any) {
+                console.error("Error initializing session:", err);
+            } finally {
+                setLoading(false);
+            }
+        };
+        initSession();
+    }, [uploadId, studentId, subjectId, termId]);
+
+    const currentItem = items[currentIndex];
+    const pairs = useMemo(() => (currentItem ? getPairs(currentItem) : []), [currentItem]);
+    const rightOptions = useMemo(() => shuffle(pairs.map((p) => p.right)), [pairs]);
+
+    useEffect(() => {
+        setAssignments({});
+        setFeedback(null);
+        setQuestionStartTime(new Date());
+    }, [currentIndex]);
+
+    if (loading) return <p>Cargando actividad...</p>;
+    if (!sessionId || !activityTypeId) return <p>Error al iniciar la sesión.</p>;
+    if (items.length === 0) return <p>No hay ítems MATCH disponibles para este contenido.</p>;
+
+    const submit = async () => {
+        if (feedback) return;
+        const endTime = new Date();
+        const durationMs = endTime.getTime() - questionStartTime.getTime();
+
+        const expected = Object.fromEntries(pairs.map((p) => [p.left, p.right]));
+        const isComplete = pairs.every((p) => assignments[p.left]);
+        const isCorrect = isComplete && JSON.stringify(assignments) === JSON.stringify(expected);
+
+        setFeedback({
+            isCorrect,
+            text: isCorrect ? "Correcto." : "Revisa tus emparejamientos e inténtalo de nuevo en la siguiente.",
+        });
+
+        try {
+            await api.post(`/activities/sessions/${sessionId}/responses`, {
+                student_id: studentId,
+                item_id: currentItem.id,
+                subject_id: subjectId,
+                term_id: termId,
+                topic_id: null,
+                microconcept_id: null,
+                activity_type_id: activityTypeId,
+                is_correct: isCorrect,
+                duration_ms: durationMs,
+                attempt_number: 1,
+                response_normalized: JSON.stringify(assignments),
+                hint_used: null,
+                difficulty_at_time: null,
+                timestamp_start: questionStartTime.toISOString(),
+                timestamp_end: endTime.toISOString(),
+            });
+        } catch (err: any) {
+            console.error("Error recording event:", err);
+        }
+    };
+
+    const next = async () => {
+        if (currentIndex < items.length - 1) {
+            setCurrentIndex((i) => i + 1);
+            return;
+        }
+        try {
+            await api.post(`/activities/sessions/${sessionId}/end`);
+        } catch (err: any) {
+            console.error("Error ending session:", err);
+        }
+        setFinished(true);
+    };
+
+    if (finished) {
+        return (
+            <div className="card" style={{ textAlign: "center" }}>
+                <h3>Actividad Completada</h3>
+                <p style={{ color: "var(--text-secondary)" }}>Tus métricas se han actualizado automáticamente.</p>
+                <button onClick={onExit} className="btn">
+                    Volver al inicio
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="card" style={{ maxWidth: "700px", margin: "0 auto" }}>
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    marginBottom: "1rem",
+                    color: "var(--text-secondary)",
+                }}
+            >
+                <span>Ítem {currentIndex + 1} de {items.length}</span>
+                <span>MATCH</span>
+            </div>
+
+            <h3 style={{ marginBottom: "1.5rem" }}>{currentItem.stem}</h3>
+
+            {pairs.length === 0 ? (
+                <p>Error: el ítem no tiene pares configurados.</p>
+            ) : (
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem" }}>
+                    <div style={{ fontWeight: 600, color: "var(--text-secondary)" }}>Izquierda</div>
+                    <div style={{ fontWeight: 600, color: "var(--text-secondary)" }}>Derecha</div>
+
+                    {pairs.map((pair) => (
+                        <Fragment key={pair.left}>
+                            <div className="input" style={{ display: "flex", alignItems: "center" }}>
+                                {pair.left}
+                            </div>
+                            <select
+                                className="input"
+                                value={assignments[pair.left] || ""}
+                                onChange={(e) =>
+                                    setAssignments((prev) => ({ ...prev, [pair.left]: e.target.value }))
+                                }
+                                disabled={!!feedback}
+                            >
+                                <option value="" disabled>
+                                    Selecciona…
+                                </option>
+                                {rightOptions.map((opt) => (
+                                    <option key={opt} value={opt}>
+                                        {opt}
+                                    </option>
+                                ))}
+                            </select>
+                        </Fragment>
+                    ))}
+                </div>
+            )}
+
+            <div style={{ display: "flex", gap: "0.75rem", marginTop: "1.5rem" }}>
+                <button className="btn" onClick={submit} disabled={!!feedback || pairs.length === 0}>
+                    Enviar
+                </button>
+                {feedback && (
+                    <button className="btn btn-secondary" onClick={next}>
+                        Siguiente
+                    </button>
+                )}
+            </div>
+
+            {feedback && (
+                <div
+                    style={{
+                        marginTop: "1rem",
+                        padding: "1rem",
+                        backgroundColor: "var(--bg-primary)",
+                        borderRadius: "var(--radius-md)",
+                    }}
+                >
+                    <p style={{ color: feedback.isCorrect ? "var(--success)" : "var(--error)", fontWeight: "bold" }}>
+                        {feedback.text}
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/tutor/MetricsDashboard.tsx
+++ b/frontend/src/components/tutor/MetricsDashboard.tsx
@@ -175,7 +175,7 @@ export default function MetricsDashboard({ studentId, subjectId, termId }: Metri
                                 {bootstrapLoading ? 'Inicializando...' : 'Inicializar dominio (dev)'}
                             </button>
                             <span style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
-                                Crea un microconcepto "General" para este subject/term y alinea items/eventos.
+                                Crea un microconcepto &quot;General&quot; para este subject/term y alinea items/eventos.
                             </span>
                         </div>
                     </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosHeaders } from 'axios';
 
 export const ACCESS_TOKEN_STORAGE_KEY = 'decies.access_token';
 
@@ -13,8 +13,9 @@ api.interceptors.request.use((config) => {
     if (typeof window !== 'undefined') {
         const token = window.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
         if (token) {
-            config.headers = config.headers ?? {};
-            config.headers.Authorization = `Bearer ${token}`;
+            const headers = AxiosHeaders.from(config.headers ?? {});
+            headers.set('Authorization', `Bearer ${token}`);
+            config.headers = headers;
         }
     }
     return config;


### PR DESCRIPTION
Sprint 2 Day 4 (Issue #29): add new activity type MATCH end-to-end.

Backend:
- Adds ItemType.MATCH (enum + migration)
- Adds /activities/sessions/{id}/items and filters session item selection by activity type + is_active
- MATCH responses compute is_correct from submitted mapping

Frontend:
- Adds student MatchRunner and entry from /student
- QuizRunner now uses session items endpoint
- Fixes axios header typing so Next build passes