### PR TITLE
fix(student): reload uploads after login

### DIFF
--- a/frontend/src/app/student/page.tsx
+++ b/frontend/src/app/student/page.tsx
@@ -22,21 +22,30 @@ export default function StudentPage() {
     const [selectedMode, setSelectedMode] = useState<'QUIZ' | 'MATCH'>('QUIZ');
     const [me, setMe] = useState<AuthMe | null>(null);
 
+    const studentId = me?.student_id || '';
+
     useEffect(() => {
-        const init = async () => {
+        const loadUploads = async () => {
+            if (!studentId) {
+                setUploads([]);
+                setLoading(false);
+                return;
+            }
+
+            setLoading(true);
             try {
                 const res: any = await api.get('/content/uploads');
                 setUploads(res.data);
             } catch (err: any) {
                 console.error(err);
+                setUploads([]);
             } finally {
                 setLoading(false);
             }
-        }
-        init();
-    }, []);
+        };
 
-    const studentId = me?.student_id || '';
+        loadUploads();
+    }, [studentId]);
 
     if (selectedUpload) {
         if (!studentId) {


### PR DESCRIPTION
Fix student page UX: after logging in, reload /content/uploads so the user can immediately start Quiz/MATCH without refreshing.