### PR TITLE
fix(db): ensure MATCH item_type label

### DIFF
--- a/backend/alembic/versions/8fd02f1678c7_ensure_match_item_type_label.py
+++ b/backend/alembic/versions/8fd02f1678c7_ensure_match_item_type_label.py
@@ -1,0 +1,38 @@
+"""ensure MATCH item_type label
+
+Revision ID: 8fd02f1678c7
+Revises: 9a31fa56887f
+Create Date: 2025-12-18 20:17:32.461507
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "8fd02f1678c7"
+down_revision: str | None = "9a31fa56887f"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # Some DBs may have applied an earlier migration that added 'match' instead of 'MATCH'.
+    # SQLAlchemy stores enum member names (e.g. 'MATCH'), so we ensure that label exists.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TYPE item_type ADD VALUE 'MATCH';
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Enum values can't be removed easily in Postgres; no-op.
+    return None


### PR DESCRIPTION
Adds a follow-up Alembic migration to ensure the Postgres enum item_type contains the 'MATCH' label. This fixes environments that applied the earlier Day 4 migration when it incorrectly added 'match' (lowercase), which breaks seed + queries.