### PR TITLE
feat(activities): session feedback + report

### DIFF
--- a/backend/alembic/versions/39dfe007d819_add_session_feedback.py
+++ b/backend/alembic/versions/39dfe007d819_add_session_feedback.py
@@ -12,19 +12,21 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = '39dfe007d819'
-down_revision: str | None = '8fd02f1678c7'
+revision: str = "39dfe007d819"
+down_revision: str | None = "8fd02f1678c7"
 branch_labels: str | None = None
 depends_on: str | None = None
 
 
 def upgrade() -> None:
-    op.add_column('activity_sessions', sa.Column('feedback_rating', sa.Integer(), nullable=True))
-    op.add_column('activity_sessions', sa.Column('feedback_text', sa.Text(), nullable=True))
-    op.add_column('activity_sessions', sa.Column('feedback_submitted_at', sa.DateTime(), nullable=True))
+    op.add_column("activity_sessions", sa.Column("feedback_rating", sa.Integer(), nullable=True))
+    op.add_column("activity_sessions", sa.Column("feedback_text", sa.Text(), nullable=True))
+    op.add_column(
+        "activity_sessions", sa.Column("feedback_submitted_at", sa.DateTime(), nullable=True)
+    )
 
 
 def downgrade() -> None:
-    op.drop_column('activity_sessions', 'feedback_submitted_at')
-    op.drop_column('activity_sessions', 'feedback_text')
-    op.drop_column('activity_sessions', 'feedback_rating')
+    op.drop_column("activity_sessions", "feedback_submitted_at")
+    op.drop_column("activity_sessions", "feedback_text")
+    op.drop_column("activity_sessions", "feedback_rating")

--- a/backend/alembic/versions/39dfe007d819_add_session_feedback.py
+++ b/backend/alembic/versions/39dfe007d819_add_session_feedback.py
@@ -1,0 +1,30 @@
+"""add session feedback
+
+Revision ID: 39dfe007d819
+Revises: 8fd02f1678c7
+Create Date: 2025-12-18 22:37:58.694364
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = '39dfe007d819'
+down_revision: str | None = '8fd02f1678c7'
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column('activity_sessions', sa.Column('feedback_rating', sa.Integer(), nullable=True))
+    op.add_column('activity_sessions', sa.Column('feedback_text', sa.Text(), nullable=True))
+    op.add_column('activity_sessions', sa.Column('feedback_submitted_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('activity_sessions', 'feedback_submitted_at')
+    op.drop_column('activity_sessions', 'feedback_text')
+    op.drop_column('activity_sessions', 'feedback_rating')

--- a/backend/app/models/activity.py
+++ b/backend/app/models/activity.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    Text,
     text,
 )
 from sqlalchemy.dialects.postgresql import UUID
@@ -61,6 +62,9 @@ class ActivitySession(Base):
     status: Mapped[str] = mapped_column(
         String(50), default="in_progress", nullable=False
     )  # in_progress, completed, abandoned
+    feedback_rating: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    feedback_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    feedback_submitted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     device_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=True

--- a/backend/app/schemas/activity.py
+++ b/backend/app/schemas/activity.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ActivityTypeBase(BaseModel):
@@ -34,6 +34,11 @@ class ActivitySessionBase(BaseModel):
 class ActivitySessionCreate(ActivitySessionBase):
     item_count: int = 10  # Number of items to include in session
     content_upload_id: uuid.UUID | None = None
+
+
+class ActivitySessionFeedbackCreate(BaseModel):
+    rating: int | None = Field(default=None, ge=1, le=5)
+    text: str | None = Field(default=None, max_length=2000)
 
 
 class ActivitySessionResponse(ActivitySessionBase):

--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -6,11 +6,15 @@ from fastapi.testclient import TestClient
 
 from app.core.db import SessionLocal
 from app.main import app
-from app.models.activity import ActivityType
-from app.models.item import Item
+from app.models.activity import ActivitySessionItem, ActivityType
+from app.models.content import ContentUpload, ContentUploadType
+from app.models.item import Item, ItemType
+from app.models.metric import MasteryState
+from app.models.microconcept import MicroConcept
 from app.models.student import Student
 from app.models.subject import Subject
 from app.models.term import Term
+from app.models.tutor import Tutor
 
 client = TestClient(app)
 
@@ -194,3 +198,140 @@ def test_list_activity_types(db_session):
     data = response.json()
     assert len(data) >= 3  # QUIZ, MATCH, REVIEW from seed
     assert any(t["code"] == "QUIZ" for t in data)
+
+
+def test_create_activity_session_adaptive_selection_prioritizes_at_risk(db_session):
+    token_res = client.post(
+        "/api/v1/login/access-token",
+        json={"email": "student@decies.com", "password": "decies"},
+    )
+    assert token_res.status_code == 200
+    token = token_res.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    me_res = client.get("/api/v1/auth/me", headers=headers)
+    assert me_res.status_code == 200
+    student_id = uuid.UUID(me_res.json()["student_id"])
+
+    student = db_session.get(Student, student_id)
+    assert student is not None
+
+    subject = db_session.get(Subject, student.subject_id)
+    term = db_session.query(Term).filter_by(code="T1").first()
+    activity_type = db_session.query(ActivityType).filter_by(code="QUIZ").first()
+    tutor = db_session.query(Tutor).first()
+    assert subject is not None
+    assert term is not None
+    assert activity_type is not None
+    assert tutor is not None
+
+    microconcepts = (
+        db_session.query(MicroConcept)
+        .filter(MicroConcept.subject_id == subject.id, MicroConcept.term_id == term.id)
+        .order_by(MicroConcept.code.asc())
+        .limit(3)
+        .all()
+    )
+    assert len(microconcepts) == 3
+
+    upload = ContentUpload(
+        id=uuid.uuid4(),
+        file_name="adaptive_selection_test.pdf",
+        storage_uri="/test/adaptive_selection_test.pdf",
+        mime_type="application/pdf",
+        upload_type=ContentUploadType.pdf,
+        tutor_id=tutor.id,
+        subject_id=subject.id,
+        term_id=term.id,
+        page_count=1,
+    )
+    db_session.add(upload)
+    db_session.flush()
+
+    for idx, mc in enumerate(microconcepts):
+        for j in range(3):
+            item = Item(
+                id=uuid.uuid4(),
+                content_upload_id=upload.id,
+                microconcept_id=mc.id,
+                type=ItemType.MCQ,
+                stem=f"Pregunta adaptativa {idx}-{j}",
+                options=["A", "B", "C", "D"],
+                correct_answer="A",
+                explanation="",
+                difficulty=1,
+                is_active=True,
+            )
+            db_session.add(item)
+
+    # Mastery setup:
+    # - First microconcept at_risk
+    # - Second in_progress
+    # - Third dominant (should be de-prioritized)
+    now = datetime.utcnow()
+    statuses = ["at_risk", "in_progress", "dominant"]
+    scores = [0.2, 0.6, 0.9]
+    for mc, status, score in zip(microconcepts, statuses, scores, strict=True):
+        existing = (
+            db_session.query(MasteryState)
+            .filter(MasteryState.student_id == student.id, MasteryState.microconcept_id == mc.id)
+            .first()
+        )
+        if existing:
+            existing.status = status
+            existing.mastery_score = score
+            existing.updated_at = now
+            existing.last_practice_at = now
+        else:
+            db_session.add(
+                MasteryState(
+                    id=uuid.uuid4(),
+                    student_id=student.id,
+                    microconcept_id=mc.id,
+                    mastery_score=score,
+                    status=status,
+                    last_practice_at=now,
+                    updated_at=now,
+                    metrics_version="V1",
+                )
+            )
+
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/activities/sessions",
+        json={
+            "student_id": str(student.id),
+            "activity_type_id": str(activity_type.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "topic_id": None,
+            "item_count": 6,
+            "content_upload_id": str(upload.id),
+            "device_type": "web",
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    session_id = uuid.UUID(response.json()["id"])
+
+    selected = (
+        db_session.query(Item)
+        .join(ActivitySessionItem, ActivitySessionItem.item_id == Item.id)
+        .filter(ActivitySessionItem.session_id == session_id)
+        .order_by(ActivitySessionItem.order_index.asc())
+        .all()
+    )
+    assert len(selected) == 6
+    selected_microconcepts = [i.microconcept_id for i in selected]
+
+    assert microconcepts[0].id in selected_microconcepts[:3]
+    assert microconcepts[1].id in selected_microconcepts[:3]
+
+    counts: dict[uuid.UUID, int] = {}
+    for mcid in selected_microconcepts:
+        assert mcid is not None
+        counts[mcid] = counts.get(mcid, 0) + 1
+
+    assert max(counts.values()) <= 2

--- a/frontend/src/components/student/MatchRunner.tsx
+++ b/frontend/src/components/student/MatchRunner.tsx
@@ -49,6 +49,11 @@ export default function MatchRunner({ uploadId, studentId, subjectId, termId, on
     const [assignments, setAssignments] = useState<Record<string, string>>({});
     const [feedback, setFeedback] = useState<{ isCorrect: boolean; text: string } | null>(null);
     const [questionStartTime, setQuestionStartTime] = useState<Date>(new Date());
+    const [sessionFeedbackRating, setSessionFeedbackRating] = useState<number>(5);
+    const [sessionFeedbackText, setSessionFeedbackText] = useState<string>('');
+    const [sessionFeedbackSubmitting, setSessionFeedbackSubmitting] = useState(false);
+    const [sessionFeedbackSubmitted, setSessionFeedbackSubmitted] = useState(false);
+    const [sessionFeedbackError, setSessionFeedbackError] = useState<string>('');
 
     useEffect(() => {
         const initSession = async () => {
@@ -151,15 +156,74 @@ export default function MatchRunner({ uploadId, studentId, subjectId, termId, on
         setFinished(true);
     };
 
+    const submitSessionFeedback = async () => {
+        if (!sessionId || sessionFeedbackSubmitted) return;
+        setSessionFeedbackSubmitting(true);
+        setSessionFeedbackError('');
+        try {
+            await api.post(`/activities/sessions/${sessionId}/feedback`, {
+                rating: sessionFeedbackRating,
+                text: sessionFeedbackText || null,
+            });
+            setSessionFeedbackSubmitted(true);
+        } catch (err: any) {
+            setSessionFeedbackError(err?.response?.data?.detail || err?.message || 'Error enviando feedback');
+        } finally {
+            setSessionFeedbackSubmitting(false);
+        }
+    };
+
     if (finished) {
         return (
-            <div className="card" style={{ textAlign: "center" }}>
-                <h3>Actividad Completada</h3>
-                <p style={{ color: "var(--text-secondary)" }}>Tus métricas se han actualizado automáticamente.</p>
-                <button onClick={onExit} className="btn">
-                    Volver al inicio
-                </button>
-            </div>
+                <div className="card" style={{ textAlign: "center" }}>
+                    <h3>Actividad Completada</h3>
+                    <p style={{ color: "var(--text-secondary)" }}>Tus métricas se han actualizado automáticamente.</p>
+
+                    <div style={{ marginTop: "1.5rem", textAlign: "left" }}>
+                        <h4 style={{ marginTop: 0 }}>Feedback (opcional)</h4>
+                        <label style={{ display: "block", marginBottom: "0.75rem" }}>
+                            Valoración
+                            <select
+                                className="input"
+                                value={sessionFeedbackRating}
+                                onChange={(e) => setSessionFeedbackRating(Number(e.target.value))}
+                                disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                            >
+                                {[1, 2, 3, 4, 5].map((v) => (
+                                    <option key={v} value={v}>{v}</option>
+                                ))}
+                            </select>
+                        </label>
+                        <label style={{ display: "block" }}>
+                            Comentario
+                            <textarea
+                                className="input"
+                                rows={3}
+                                value={sessionFeedbackText}
+                                onChange={(e) => setSessionFeedbackText(e.target.value)}
+                                disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                                placeholder="¿Qué te ha parecido la sesión?"
+                            />
+                        </label>
+                        {sessionFeedbackError && (
+                            <p style={{ color: "var(--error)", marginTop: "0.75rem" }}>{sessionFeedbackError}</p>
+                        )}
+                        {sessionFeedbackSubmitted && (
+                            <p style={{ color: "var(--success)", marginTop: "0.75rem" }}>Feedback enviado.</p>
+                        )}
+                        <button
+                            onClick={submitSessionFeedback}
+                            className="btn btn-secondary"
+                            disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                            style={{ marginTop: "0.75rem" }}
+                        >
+                            {sessionFeedbackSubmitting ? "Enviando..." : "Enviar feedback"}
+                        </button>
+                    </div>
+                    <button onClick={onExit} className="btn">
+                        Volver al inicio
+                    </button>
+                </div>
         );
     }
 

--- a/frontend/src/components/student/QuizRunner.tsx
+++ b/frontend/src/components/student/QuizRunner.tsx
@@ -31,6 +31,11 @@ export default function QuizRunner({ uploadId, studentId, subjectId, termId, onE
     const [selectedOption, setSelectedOption] = useState<string | null>(null);
     const [feedback, setFeedback] = useState<{ isCorrect: boolean, text: string } | null>(null);
     const [questionStartTime, setQuestionStartTime] = useState<Date>(new Date());
+    const [sessionFeedbackRating, setSessionFeedbackRating] = useState<number>(5);
+    const [sessionFeedbackText, setSessionFeedbackText] = useState<string>('');
+    const [sessionFeedbackSubmitting, setSessionFeedbackSubmitting] = useState(false);
+    const [sessionFeedbackSubmitted, setSessionFeedbackSubmitted] = useState(false);
+    const [sessionFeedbackError, setSessionFeedbackError] = useState<string>('');
 
     useEffect(() => {
         const initSession = async () => {
@@ -146,6 +151,23 @@ export default function QuizRunner({ uploadId, studentId, subjectId, termId, onE
         setFinished(true);
     };
 
+    const submitSessionFeedback = async () => {
+        if (!sessionId || sessionFeedbackSubmitted) return;
+        setSessionFeedbackSubmitting(true);
+        setSessionFeedbackError('');
+        try {
+            await api.post(`/activities/sessions/${sessionId}/feedback`, {
+                rating: sessionFeedbackRating,
+                text: sessionFeedbackText || null,
+            });
+            setSessionFeedbackSubmitted(true);
+        } catch (err: any) {
+            setSessionFeedbackError(err?.response?.data?.detail || err?.message || 'Error enviando feedback');
+        } finally {
+            setSessionFeedbackSubmitting(false);
+        }
+    };
+
     if (finished) {
         return (
             <div className="card" style={{ textAlign: 'center' }}>
@@ -154,6 +176,48 @@ export default function QuizRunner({ uploadId, studentId, subjectId, termId, onE
                 <p style={{ color: 'var(--text-secondary)' }}>
                     Tus métricas se han actualizado automáticamente.
                 </p>
+
+                <div style={{ marginTop: '1.5rem', textAlign: 'left' }}>
+                    <h4 style={{ marginTop: 0 }}>Feedback (opcional)</h4>
+                    <label style={{ display: 'block', marginBottom: '0.75rem' }}>
+                        Valoración
+                        <select
+                            className="input"
+                            value={sessionFeedbackRating}
+                            onChange={(e) => setSessionFeedbackRating(Number(e.target.value))}
+                            disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                        >
+                            {[1, 2, 3, 4, 5].map((v) => (
+                                <option key={v} value={v}>{v}</option>
+                            ))}
+                        </select>
+                    </label>
+                    <label style={{ display: 'block' }}>
+                        Comentario
+                        <textarea
+                            className="input"
+                            rows={3}
+                            value={sessionFeedbackText}
+                            onChange={(e) => setSessionFeedbackText(e.target.value)}
+                            disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                            placeholder="¿Qué te ha parecido la sesión?"
+                        />
+                    </label>
+                    {sessionFeedbackError && (
+                        <p style={{ color: 'var(--error)', marginTop: '0.75rem' }}>{sessionFeedbackError}</p>
+                    )}
+                    {sessionFeedbackSubmitted && (
+                        <p style={{ color: 'var(--success)', marginTop: '0.75rem' }}>Feedback enviado.</p>
+                    )}
+                    <button
+                        onClick={submitSessionFeedback}
+                        className="btn btn-secondary"
+                        disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                        style={{ marginTop: '0.75rem' }}
+                    >
+                        {sessionFeedbackSubmitting ? 'Enviando...' : 'Enviar feedback'}
+                    </button>
+                </div>
                 <button onClick={onExit} className="btn">Volver al inicio</button>
             </div>
         );


### PR DESCRIPTION
Implements Sprint 2 Día 6: feedback cualitativo post-sesión + integración en informe.\n\n- Adds optional feedback fields to ctivity_sessions (+ alembic migration).\n- New endpoint: POST /activities/sessions/{id}/feedback (student-only, requires completed session).\n- Report includes new section student_feedback with last 5 feedback entries.\n- Student UI (Quiz/Match) can submit feedback after finishing.\n\nNota: esta rama incluye como base el trabajo de Día 5 (PR #42) para evitar conflictos en ctivity.py.