### PR TITLE
fix(frontend): guard match when unavailable

### DIFF
--- a/frontend/src/components/student/MatchRunner.tsx
+++ b/frontend/src/components/student/MatchRunner.tsx
@@ -103,6 +103,8 @@ export default function MatchRunner({ uploadId, studentId, subjectId, termId, on
                 if (!cancelled) {
                     if (detail === 'Not enough permissions') {
                         setInitError('Necesitas iniciar sesión como estudiante.');
+                    } else if (detail === 'No items found for this subject/term') {
+                        setInitError('Este contenido aún no tiene ítems MATCH. Por ahora usa Quiz.');
                     } else if (typeof detail === 'string' && detail.length > 0) {
                         setInitError(detail);
                     } else {

--- a/frontend/src/components/student/QuizRunner.tsx
+++ b/frontend/src/components/student/QuizRunner.tsx
@@ -90,6 +90,8 @@ export default function QuizRunner({ uploadId, studentId, subjectId, termId, onE
                 if (!cancelled) {
                     if (detail === 'Not enough permissions') {
                         setInitError('Necesitas iniciar sesión como estudiante.');
+                    } else if (detail === 'No items found for this subject/term') {
+                        setInitError('Este contenido aún no tiene preguntas de Quiz. Pide al tutor que lo procese.');
                     } else if (typeof detail === 'string' && detail.length > 0) {
                         setInitError(detail);
                     } else {


### PR DESCRIPTION
Evita el error "No items found for this subject/term" al abrir MATCH en contenidos sin items MATCH.

- En /student, hace preflight a /content/uploads/{id}/items y solo permite abrir MATCH si hay items type=match.
- Mensaje mas claro en MatchRunner/QuizRunner cuando el backend responde 404 por falta de items.
