### PR TITLE
feat(microconcepts): tutor RBAC + update endpoint

### DIFF
--- a/backend/app/routers/microconcepts.py
+++ b/backend/app/routers/microconcepts.py
@@ -4,13 +4,24 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.core.db import get_db
+from app.core.deps import get_current_active_user, require_roles
 from app.models.activity import LearningEvent
 from app.models.content import ContentUpload
 from app.models.item import Item
 from app.models.microconcept import MicroConcept
-from app.schemas.microconcept import MicroConceptCreate, MicroConceptResponse
+from app.models.subject import Subject
+from app.models.user import User
+from app.schemas.microconcept import MicroConceptCreate, MicroConceptResponse, MicroConceptUpdate
 
 router = APIRouter(prefix="/microconcepts", tags=["microconcepts"])
+
+
+def _require_tutor_owns_subject(db: Session, current_user: User, subject_id: uuid.UUID) -> Subject:
+    require_roles(db, current_user, {"tutor"})
+    subject = db.get(Subject, subject_id)
+    if not subject or subject.tutor_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not enough permissions")
+    return subject
 
 
 @router.get("/subjects/{subject_id}", response_model=list[MicroConceptResponse])
@@ -18,10 +29,15 @@ def list_microconcepts(
     subject_id: uuid.UUID,
     term_id: uuid.UUID | None = None,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     List all microconcepts for a subject (optionally filtered by term).
+
+    Tutor-only: the tutor must own the subject.
     """
+    _require_tutor_owns_subject(db=db, current_user=current_user, subject_id=subject_id)
+
     query = db.query(MicroConcept).filter(
         MicroConcept.subject_id == subject_id,
         MicroConcept.active == True,  # noqa: E712
@@ -36,10 +52,18 @@ def list_microconcepts(
 
 
 @router.post("", response_model=MicroConceptResponse)
-def create_microconcept(microconcept_data: MicroConceptCreate, db: Session = Depends(get_db)):
+def create_microconcept(
+    microconcept_data: MicroConceptCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
     """
-    Create a new microconcept (tutor/admin only in production).
+    Create a new microconcept (tutor-only).
     """
+    _require_tutor_owns_subject(
+        db=db, current_user=current_user, subject_id=microconcept_data.subject_id
+    )
+
     microconcept = MicroConcept(
         id=uuid.uuid4(),
         subject_id=microconcept_data.subject_id,
@@ -59,13 +83,50 @@ def create_microconcept(microconcept_data: MicroConceptCreate, db: Session = Dep
 
 
 @router.get("/{microconcept_id}", response_model=MicroConceptResponse)
-def get_microconcept(microconcept_id: uuid.UUID, db: Session = Depends(get_db)):
+def get_microconcept(
+    microconcept_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
     """
     Get a microconcept by ID.
     """
     microconcept = db.query(MicroConcept).filter_by(id=microconcept_id).first()
     if not microconcept:
         raise HTTPException(status_code=404, detail="Microconcept not found")
+
+    _require_tutor_owns_subject(
+        db=db, current_user=current_user, subject_id=microconcept.subject_id
+    )
+
+    return microconcept
+
+
+@router.patch("/{microconcept_id}", response_model=MicroConceptResponse)
+def update_microconcept(
+    microconcept_id: uuid.UUID,
+    microconcept_update: MicroConceptUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    """
+    Patch a microconcept (tutor-only).
+    """
+    microconcept = db.query(MicroConcept).filter_by(id=microconcept_id).first()
+    if not microconcept:
+        raise HTTPException(status_code=404, detail="Microconcept not found")
+
+    _require_tutor_owns_subject(
+        db=db, current_user=current_user, subject_id=microconcept.subject_id
+    )
+
+    updates = microconcept_update.model_dump(exclude_unset=True)
+    for field_name, value in updates.items():
+        setattr(microconcept, field_name, value)
+
+    db.add(microconcept)
+    db.commit()
+    db.refresh(microconcept)
 
     return microconcept
 
@@ -75,6 +136,7 @@ def bootstrap_microconcepts_for_scope(
     subject_id: uuid.UUID,
     term_id: uuid.UUID,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     Dev-only helper: ensures the subject/term has at least one microconcept ("General"),
@@ -83,6 +145,8 @@ def bootstrap_microconcepts_for_scope(
     This unblocks mastery calculations when the dataset has practice sessions but no
     microconcept taxonomy yet.
     """
+    _require_tutor_owns_subject(db=db, current_user=current_user, subject_id=subject_id)
+
     microconcept = (
         db.query(MicroConcept)
         .filter(

--- a/backend/app/schemas/microconcept.py
+++ b/backend/app/schemas/microconcept.py
@@ -18,6 +18,15 @@ class MicroConceptCreate(MicroConceptBase):
     pass
 
 
+class MicroConceptUpdate(BaseModel):
+    term_id: uuid.UUID | None = None
+    topic_id: uuid.UUID | None = None
+    code: str | None = None
+    name: str | None = None
+    description: str | None = None
+    active: bool | None = None
+
+
 class MicroConceptResponse(MicroConceptBase):
     id: uuid.UUID
     created_at: datetime | None

--- a/backend/tests/test_microconcepts.py
+++ b/backend/tests/test_microconcepts.py
@@ -1,0 +1,154 @@
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.main import app
+from app.models.microconcept import MicroConcept
+from app.models.role import Role
+from app.models.subject import Subject
+from app.models.term import AcademicYear, Term
+from app.models.tutor import Tutor
+from app.models.user import User
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def db_session() -> Session:
+    from app.core.db import SessionLocal
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _get_or_create_role(db: Session, name: str) -> Role:
+    role = db.query(Role).filter(func.lower(Role.name) == name.casefold()).first()
+    if role:
+        return role
+    role = Role(name=name)
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    return role
+
+
+def _login(email: str, password: str) -> dict[str, str]:
+    token_res = client.post(
+        "/api/v1/login/access-token", json={"email": email, "password": password}
+    )
+    assert token_res.status_code == 200
+    return {"Authorization": f"Bearer {token_res.json()['access_token']}"}
+
+
+def _create_tutor_scope(db: Session) -> tuple[User, Tutor, Subject, Term, dict[str, str]]:
+    role = _get_or_create_role(db, "tutor")
+    password = "pw"
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        email=f"tutor_mc_{user_id}@test.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role.id,
+    )
+    db.add(user)
+    db.flush()
+
+    tutor = Tutor(user_id=user.id, display_name="Test Tutor")
+    db.add(tutor)
+    db.flush()
+
+    ac_year = AcademicYear(
+        name=f"2025-2026-mc-{user_id}",
+        start_date="2025-09-01",
+        end_date="2026-06-30",
+    )
+    db.add(ac_year)
+    db.flush()
+
+    term = Term(academic_year_id=ac_year.id, code="T1", name="Term 1")
+    subject = Subject(name=f"Subject MC {user_id}", tutor_id=user.id)
+    db.add_all([term, subject])
+    db.commit()
+
+    headers = _login(user.email, password)
+    return user, tutor, subject, term, headers
+
+
+def test_microconcepts_tutor_can_create_list_and_update(db_session: Session):
+    _user, _tutor, subject, term, headers = _create_tutor_scope(db_session)
+
+    create_res = client.post(
+        "/api/v1/microconcepts",
+        json={
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "topic_id": None,
+            "code": "MC-T-001",
+            "name": "Números enteros",
+            "description": "Concepto base",
+            "active": True,
+        },
+        headers=headers,
+    )
+    assert create_res.status_code == 200
+    mc_id = create_res.json()["id"]
+
+    list_res = client.get(
+        f"/api/v1/microconcepts/subjects/{subject.id}",
+        params={"term_id": str(term.id)},
+        headers=headers,
+    )
+    assert list_res.status_code == 200
+    assert any(row["id"] == mc_id for row in list_res.json())
+
+    patch_res = client.patch(
+        f"/api/v1/microconcepts/{mc_id}",
+        json={"name": "Números enteros (editado)", "active": False},
+        headers=headers,
+    )
+    assert patch_res.status_code == 200
+    assert patch_res.json()["name"] == "Números enteros (editado)"
+    assert patch_res.json()["active"] is False
+
+    mc = db_session.query(MicroConcept).filter_by(id=uuid.UUID(mc_id)).first()
+    assert mc is not None
+    assert mc.active is False
+
+
+def test_microconcepts_student_forbidden(db_session: Session):
+    role_student = _get_or_create_role(db_session, "student")
+    password = "pw"
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        email=f"student_mc_{user_id}@test.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add(user)
+    db_session.commit()
+    headers = _login(user.email, password)
+
+    res = client.get(f"/api/v1/microconcepts/subjects/{uuid.uuid4()}", headers=headers)
+    assert res.status_code == 403
+
+
+def test_microconcepts_tutor_cannot_access_other_tutor_subject(db_session: Session):
+    _user_a, _tutor_a, _subject_a, _term_a, headers_a = _create_tutor_scope(db_session)
+    _user_b, _tutor_b, subject_b, term_b, _headers_b = _create_tutor_scope(db_session)
+
+    res = client.get(
+        f"/api/v1/microconcepts/subjects/{subject_b.id}",
+        params={"term_id": str(term_b.id)},
+        headers=headers_a,
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
Sprint 3 Day 1 (backend):

- Restrict microconcept endpoints to tutor role
- Enforce subject ownership (tutor_id must match)
- Add PATCH /microconcepts/{id}
- Add tests for tutor create/list/update and forbidden access