### PR TITLE
feat(tutor): add microconcept management

### DIFF
--- a/backend/app/routers/microconcepts.py
+++ b/backend/app/routers/microconcepts.py
@@ -28,6 +28,7 @@ def _require_tutor_owns_subject(db: Session, current_user: User, subject_id: uui
 def list_microconcepts(
     subject_id: uuid.UUID,
     term_id: uuid.UUID | None = None,
+    active: bool | None = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
@@ -38,13 +39,13 @@ def list_microconcepts(
     """
     _require_tutor_owns_subject(db=db, current_user=current_user, subject_id=subject_id)
 
-    query = db.query(MicroConcept).filter(
-        MicroConcept.subject_id == subject_id,
-        MicroConcept.active == True,  # noqa: E712
-    )
+    query = db.query(MicroConcept).filter(MicroConcept.subject_id == subject_id)
 
     if term_id:
         query = query.filter(MicroConcept.term_id == term_id)
+
+    if active is not None:
+        query = query.filter(MicroConcept.active == active)
 
     microconcepts = query.order_by(MicroConcept.name).all()
 

--- a/backend/tests/test_microconcepts.py
+++ b/backend/tests/test_microconcepts.py
@@ -118,6 +118,16 @@ def test_microconcepts_tutor_can_create_list_and_update(db_session: Session):
     assert patch_res.json()["name"] == "Números enteros (editado)"
     assert patch_res.json()["active"] is False
 
+    list_after_res = client.get(
+        f"/api/v1/microconcepts/subjects/{subject.id}",
+        params={"term_id": str(term.id)},
+        headers=headers,
+    )
+    assert list_after_res.status_code == 200
+    row = next((r for r in list_after_res.json() if r["id"] == mc_id), None)
+    assert row is not None
+    assert row["active"] is False
+
     mc = db_session.query(MicroConcept).filter_by(id=uuid.UUID(mc_id)).first()
     assert mc is not None
     assert mc.active is False

--- a/frontend/src/app/tutor/page.tsx
+++ b/frontend/src/app/tutor/page.tsx
@@ -7,11 +7,12 @@ import UploadList from '../../components/tutor/UploadList';
 import MetricsDashboard from '../../components/tutor/MetricsDashboard';
 import RecommendationList from '../../components/tutor/RecommendationList';
 import TutorReportPanel from '../../components/tutor/TutorReportPanel';
+import MicroconceptManager from '../../components/tutor/MicroconceptManager';
 import { AuthMe } from '../../services/auth';
 import { fetchStudents, fetchSubjects, fetchTerms, StudentSummary, SubjectSummary, TermSummary } from '../../services/catalog';
 
 export default function TutorPage() {
-    const [activeTab, setActiveTab] = useState<'content' | 'metrics' | 'recommendations' | 'reports'>('content');
+    const [activeTab, setActiveTab] = useState<'content' | 'metrics' | 'recommendations' | 'reports' | 'microconcepts'>('content');
 
     const [me, setMe] = useState<AuthMe | null>(null);
     const [subjects, setSubjects] = useState<SubjectSummary[]>([]);
@@ -168,6 +169,12 @@ export default function TutorPage() {
                         >
                             Informe
                         </button>
+                        <button
+                            onClick={() => setActiveTab('microconcepts')}
+                            style={getTabStyle('microconcepts')}
+                        >
+                            Microconceptos
+                        </button>
                     </div>
 
                     {/* Content */}
@@ -221,6 +228,17 @@ export default function TutorPage() {
                             />
                         ) : (
                             <p>Selecciona contexto para ver informes.</p>
+                        )
+                    )}
+
+                    {activeTab === 'microconcepts' && (
+                        selectedSubjectId && selectedTermId ? (
+                            <MicroconceptManager
+                                subjectId={selectedSubjectId}
+                                termId={selectedTermId}
+                            />
+                        ) : (
+                            <p>Selecciona asignatura y trimestre para gestionar microconceptos.</p>
                         )
                     )}
                 </>

--- a/frontend/src/components/tutor/MicroconceptManager.tsx
+++ b/frontend/src/components/tutor/MicroconceptManager.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+    createMicroconcept,
+    fetchMicroconcepts,
+    MicroConcept,
+    updateMicroconcept,
+} from "../../services/microconcepts";
+
+interface MicroconceptManagerProps {
+    subjectId: string;
+    termId: string;
+}
+
+function getErrorMessage(err: any): string {
+    const detail = err?.response?.data?.detail;
+    if (typeof detail === "string" && detail.length > 0) return detail;
+    return err?.message || "Error cargando microconceptos.";
+}
+
+export default function MicroconceptManager({ subjectId, termId }: MicroconceptManagerProps) {
+    const [items, setItems] = useState<MicroConcept[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
+
+    const [createCode, setCreateCode] = useState("");
+    const [createName, setCreateName] = useState("");
+    const [createDescription, setCreateDescription] = useState("");
+    const [creating, setCreating] = useState(false);
+
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const editingItem = useMemo(
+        () => items.find((i) => i.id === editingId) || null,
+        [items, editingId]
+    );
+    const [editCode, setEditCode] = useState("");
+    const [editName, setEditName] = useState("");
+    const [editDescription, setEditDescription] = useState("");
+    const [saving, setSaving] = useState(false);
+
+    const refresh = async () => {
+        if (!subjectId) return;
+        setLoading(true);
+        setError("");
+        try {
+            const data = await fetchMicroconcepts({ subjectId, termId });
+            setItems(data);
+        } catch (err: any) {
+            setError(getErrorMessage(err));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        refresh();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [subjectId, termId]);
+
+    useEffect(() => {
+        if (!editingItem) return;
+        setEditCode(editingItem.code || "");
+        setEditName(editingItem.name || "");
+        setEditDescription(editingItem.description || "");
+    }, [editingItem]);
+
+    const onCreate = async () => {
+        if (!createName.trim()) {
+            setError("El nombre es obligatorio.");
+            return;
+        }
+        setCreating(true);
+        setError("");
+        try {
+            const created = await createMicroconcept({
+                subject_id: subjectId,
+                term_id: termId || null,
+                code: createCode.trim() || null,
+                name: createName.trim(),
+                description: createDescription.trim() || null,
+                active: true,
+            });
+            setItems((prev) => [created, ...prev].sort((a, b) => a.name.localeCompare(b.name)));
+            setCreateCode("");
+            setCreateName("");
+            setCreateDescription("");
+        } catch (err: any) {
+            setError(getErrorMessage(err));
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    const startEdit = (id: string) => {
+        setEditingId(id);
+        setError("");
+    };
+
+    const cancelEdit = () => {
+        setEditingId(null);
+        setError("");
+    };
+
+    const onSave = async () => {
+        if (!editingId) return;
+        if (!editName.trim()) {
+            setError("El nombre es obligatorio.");
+            return;
+        }
+        setSaving(true);
+        setError("");
+        try {
+            const updated = await updateMicroconcept(editingId, {
+                code: editCode.trim() || null,
+                name: editName.trim(),
+                description: editDescription.trim() || null,
+            });
+            setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
+            setEditingId(null);
+        } catch (err: any) {
+            setError(getErrorMessage(err));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const toggleActive = async (mc: MicroConcept) => {
+        setError("");
+        try {
+            const updated = await updateMicroconcept(mc.id, { active: !mc.active });
+            setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
+        } catch (err: any) {
+            setError(getErrorMessage(err));
+        }
+    };
+
+    return (
+        <div className="card">
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <h3 style={{ margin: 0 }}>Microconceptos</h3>
+                <button className="btn btn-secondary" onClick={refresh} disabled={loading}>
+                    {loading ? "Cargando..." : "Refrescar"}
+                </button>
+            </div>
+
+            <div style={{ marginTop: "1rem", display: "grid", gap: "0.75rem" }}>
+                <h4 style={{ margin: 0 }}>Nuevo microconcepto</h4>
+                <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: "0.75rem" }}>
+                    <input
+                        className="input"
+                        placeholder="Código (opcional)"
+                        value={createCode}
+                        onChange={(e) => setCreateCode(e.target.value)}
+                        disabled={creating}
+                    />
+                    <input
+                        className="input"
+                        placeholder="Nombre *"
+                        value={createName}
+                        onChange={(e) => setCreateName(e.target.value)}
+                        disabled={creating}
+                    />
+                </div>
+                <textarea
+                    className="input"
+                    placeholder="Descripción (opcional)"
+                    value={createDescription}
+                    onChange={(e) => setCreateDescription(e.target.value)}
+                    disabled={creating}
+                />
+                <button className="btn" onClick={onCreate} disabled={creating}>
+                    {creating ? "Creando..." : "Crear microconcepto"}
+                </button>
+            </div>
+
+            {error && (
+                <p style={{ marginTop: "1rem", color: "var(--error)", fontWeight: 600 }}>{error}</p>
+            )}
+
+            <div style={{ marginTop: "1.5rem" }}>
+                <h4 style={{ margin: 0 }}>Listado</h4>
+
+                {items.length === 0 && !loading ? (
+                    <p style={{ color: "var(--text-secondary)", marginTop: "0.75rem" }}>
+                        No hay microconceptos todavía para este contexto.
+                    </p>
+                ) : (
+                    <div style={{ marginTop: "0.75rem", display: "grid", gap: "0.75rem" }}>
+                        {items.map((mc) => {
+                            const isEditing = editingId === mc.id;
+                            return (
+                                <div
+                                    key={mc.id}
+                                    className="card"
+                                    style={{
+                                        padding: "1rem",
+                                        borderLeft: `4px solid ${
+                                            mc.active ? "var(--success)" : "var(--border-color)"
+                                        }`,
+                                    }}
+                                >
+                                    <div
+                                        style={{
+                                            display: "flex",
+                                            justifyContent: "space-between",
+                                            gap: "1rem",
+                                        }}
+                                    >
+                                        <div style={{ flex: 1, minWidth: 0 }}>
+                                            {isEditing ? (
+                                                <div style={{ display: "grid", gap: "0.5rem" }}>
+                                                    <div
+                                                        style={{
+                                                            display: "grid",
+                                                            gridTemplateColumns: "160px 1fr",
+                                                            gap: "0.75rem",
+                                                        }}
+                                                    >
+                                                        <input
+                                                            className="input"
+                                                            placeholder="Código"
+                                                            value={editCode}
+                                                            onChange={(e) => setEditCode(e.target.value)}
+                                                            disabled={saving}
+                                                        />
+                                                        <input
+                                                            className="input"
+                                                            placeholder="Nombre *"
+                                                            value={editName}
+                                                            onChange={(e) => setEditName(e.target.value)}
+                                                            disabled={saving}
+                                                        />
+                                                    </div>
+                                                    <textarea
+                                                        className="input"
+                                                        placeholder="Descripción"
+                                                        value={editDescription}
+                                                        onChange={(e) => setEditDescription(e.target.value)}
+                                                        disabled={saving}
+                                                    />
+                                                </div>
+                                            ) : (
+                                                <>
+                                                    <div
+                                                        style={{
+                                                            display: "flex",
+                                                            alignItems: "baseline",
+                                                            gap: "0.75rem",
+                                                        }}
+                                                    >
+                                                        <h4 style={{ margin: 0, wordBreak: "break-word" }}>
+                                                            {mc.name}
+                                                        </h4>
+                                                        {mc.code && (
+                                                            <span
+                                                                style={{
+                                                                    color: "var(--text-secondary)",
+                                                                    fontSize: "0.9rem",
+                                                                }}
+                                                            >
+                                                                {mc.code}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                    {mc.description && (
+                                                        <p
+                                                            style={{
+                                                                margin: "0.5rem 0 0 0",
+                                                                color: "var(--text-secondary)",
+                                                            }}
+                                                        >
+                                                            {mc.description}
+                                                        </p>
+                                                    )}
+                                                </>
+                                            )}
+                                        </div>
+
+                                        <div
+                                            style={{
+                                                display: "flex",
+                                                flexDirection: "column",
+                                                gap: "0.5rem",
+                                                alignItems: "flex-end",
+                                            }}
+                                        >
+                                            <span
+                                                style={{
+                                                    padding: "0.25rem 0.6rem",
+                                                    borderRadius: "var(--radius-sm)",
+                                                    backgroundColor: mc.active
+                                                        ? "rgba(46, 204, 113, 0.15)"
+                                                        : "rgba(255,255,255,0.06)",
+                                                    color: mc.active
+                                                        ? "var(--success)"
+                                                        : "var(--text-secondary)",
+                                                    fontWeight: 700,
+                                                    fontSize: "0.85rem",
+                                                }}
+                                            >
+                                                {mc.active ? "Activo" : "Inactivo"}
+                                            </span>
+
+                                            <button
+                                                className="btn btn-secondary"
+                                                onClick={() => toggleActive(mc)}
+                                                disabled={saving || creating}
+                                            >
+                                                {mc.active ? "Desactivar" : "Activar"}
+                                            </button>
+
+                                            {isEditing ? (
+                                                <div style={{ display: "flex", gap: "0.5rem" }}>
+                                                    <button
+                                                        className="btn"
+                                                        onClick={onSave}
+                                                        disabled={saving}
+                                                    >
+                                                        {saving ? "Guardando..." : "Guardar"}
+                                                    </button>
+                                                    <button
+                                                        className="btn btn-secondary"
+                                                        onClick={cancelEdit}
+                                                        disabled={saving}
+                                                    >
+                                                        Cancelar
+                                                    </button>
+                                                </div>
+                                            ) : (
+                                                <button
+                                                    className="btn btn-secondary"
+                                                    onClick={() => startEdit(mc.id)}
+                                                    disabled={saving || creating}
+                                                >
+                                                    Editar
+                                                </button>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+

--- a/frontend/src/services/microconcepts.ts
+++ b/frontend/src/services/microconcepts.ts
@@ -1,0 +1,56 @@
+import api from "./api";
+
+export interface MicroConcept {
+    id: string;
+    subject_id: string;
+    term_id: string | null;
+    topic_id: string | null;
+    code: string | null;
+    name: string;
+    description: string | null;
+    active: boolean;
+    created_at: string | null;
+    updated_at: string | null;
+}
+
+export interface MicroConceptCreatePayload {
+    subject_id: string;
+    term_id: string | null;
+    topic_id?: string | null;
+    code?: string | null;
+    name: string;
+    description?: string | null;
+    active?: boolean;
+}
+
+export type MicroConceptUpdatePayload = Partial<
+    Pick<MicroConcept, "term_id" | "topic_id" | "code" | "name" | "description" | "active">
+>;
+
+export async function fetchMicroconcepts(params: {
+    subjectId: string;
+    termId?: string;
+    active?: boolean;
+}): Promise<MicroConcept[]> {
+    const res = await api.get(`/microconcepts/subjects/${params.subjectId}`, {
+        params: {
+            term_id: params.termId,
+            active: params.active,
+        },
+    });
+    return res.data;
+}
+
+export async function createMicroconcept(payload: MicroConceptCreatePayload): Promise<MicroConcept> {
+    const res = await api.post("/microconcepts", payload);
+    return res.data;
+}
+
+export async function updateMicroconcept(
+    microconceptId: string,
+    payload: MicroConceptUpdatePayload
+): Promise<MicroConcept> {
+    const res = await api.patch(`/microconcepts/${microconceptId}`, payload);
+    return res.data;
+}
+


### PR DESCRIPTION
Sprint 3 Day 1 (UI):

- Tutor tab to create/edit/activate/deactivate microconcepts for selected subject/term
- Frontend service wrapper for microconcept endpoints
- Backend list endpoint now supports active filter and returns inactive when not filtered
- Tests updated to ensure inactive microconcepts still list for tutor