### PR TITLE
feat(microconcepts): manage prerequisites

### DIFF
--- a/backend/app/schemas/microconcept.py
+++ b/backend/app/schemas/microconcept.py
@@ -45,6 +45,10 @@ class MicroConceptPrerequisiteCreate(MicroConceptPrerequisiteBase):
     pass
 
 
+class MicroConceptPrerequisiteLinkCreate(BaseModel):
+    prerequisite_microconcept_id: uuid.UUID
+
+
 class MicroConceptPrerequisiteResponse(MicroConceptPrerequisiteBase):
     id: uuid.UUID
     created_at: datetime | None

--- a/frontend/src/services/microconcepts.ts
+++ b/frontend/src/services/microconcepts.ts
@@ -54,3 +54,33 @@ export async function updateMicroconcept(
     return res.data;
 }
 
+export interface MicroConceptPrerequisite {
+    id: string;
+    microconcept_id: string;
+    prerequisite_microconcept_id: string;
+    created_at: string | null;
+}
+
+export async function fetchMicroconceptPrerequisites(
+    microconceptId: string
+): Promise<MicroConceptPrerequisite[]> {
+    const res = await api.get(`/microconcepts/${microconceptId}/prerequisites`);
+    return res.data;
+}
+
+export async function addMicroconceptPrerequisite(
+    microconceptId: string,
+    prerequisiteMicroconceptId: string
+): Promise<MicroConceptPrerequisite> {
+    const res = await api.post(`/microconcepts/${microconceptId}/prerequisites`, {
+        prerequisite_microconcept_id: prerequisiteMicroconceptId,
+    });
+    return res.data;
+}
+
+export async function removeMicroconceptPrerequisite(
+    microconceptId: string,
+    prerequisiteMicroconceptId: string
+): Promise<void> {
+    await api.delete(`/microconcepts/${microconceptId}/prerequisites/${prerequisiteMicroconceptId}`);
+}


### PR DESCRIPTION
Sprint 3 Día 2:

Backend
- Endpoints tutor-only para prerequisitos:
  - GET /microconcepts/{id}/prerequisites
  - POST /microconcepts/{id}/prerequisites
  - DELETE /microconcepts/{id}/prerequisites/{prereq_id}
- Validaciones: mismo subject/term, sin self, sin duplicados, sin ciclos

Frontend
- En pestaña Microconceptos (tutor): editor de prerequisitos por microconcepto (multi-select)