### PR TITLE
feat(activities): add CLOZE end-to-end

### DIFF
--- a/backend/alembic/versions/6a2c2e6c0a12_add_cloze_item_type.py
+++ b/backend/alembic/versions/6a2c2e6c0a12_add_cloze_item_type.py
@@ -1,0 +1,35 @@
+"""add CLOZE item type
+
+Revision ID: 6a2c2e6c0a12
+Revises: 39dfe007d819
+Create Date: 2025-12-20 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "6a2c2e6c0a12"
+down_revision: str | None = "39dfe007d819"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # SQLAlchemy stores enum member names (e.g. 'CLOZE'), so we ensure that label exists.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TYPE item_type ADD VALUE 'CLOZE';
+        EXCEPTION
+            WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Enum values can't be removed easily in Postgres; no-op.
+    return None

--- a/backend/app/models/item.py
+++ b/backend/app/models/item.py
@@ -13,6 +13,7 @@ class ItemType(str, enum.Enum):
     MCQ = "multiple_choice"
     TRUE_FALSE = "true_false"
     MATCH = "match"
+    CLOZE = "cloze"
 
 
 class Item(Base):

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -169,6 +169,7 @@ def seed_db():
         activity_types_data = [
             ("QUIZ", "Quiz Interactivo"),
             ("MATCH", "Emparejar Conceptos"),
+            ("CLOZE", "Completar Huecos"),
             ("REVIEW", "Revisión Espaciada"),
         ]
 
@@ -279,6 +280,20 @@ def seed_db():
                 db.add(item)
                 logger.info(f"Created test Item {i + 1}")
 
+            cloze_item = Item(
+                id=uuid.uuid4(),
+                content_upload_id=test_upload.id,
+                microconcept_id=first_mc.id if first_mc else None,
+                type=ItemType.CLOZE,
+                stem="Completa: 2 + 2 = ____",
+                options={"placeholder": "____"},
+                correct_answer="4",
+                explanation="2 + 2 = 4.",
+                difficulty=1,
+            )
+            db.add(cloze_item)
+            logger.info("Created test CLOZE Item")
+
             match_mcs = (
                 db.query(MicroConcept)
                 .filter(MicroConcept.subject_id == subject.id, MicroConcept.term_id == term.id)
@@ -305,6 +320,28 @@ def seed_db():
 
             db.commit()
         else:
+            existing_cloze = (
+                db.query(Item)
+                .filter(Item.content_upload_id == test_upload.id, Item.type == ItemType.CLOZE)
+                .first()
+            )
+            if not existing_cloze:
+                first_mc = db.query(MicroConcept).filter_by(code="MC-001").first()
+                cloze_item = Item(
+                    id=uuid.uuid4(),
+                    content_upload_id=test_upload.id,
+                    microconcept_id=first_mc.id if first_mc else None,
+                    type=ItemType.CLOZE,
+                    stem="Completa: 2 + 2 = ____",
+                    options={"placeholder": "____"},
+                    correct_answer="4",
+                    explanation="2 + 2 = 4.",
+                    difficulty=1,
+                )
+                db.add(cloze_item)
+                db.commit()
+                logger.info("Created missing test CLOZE Item")
+
             existing_match = (
                 db.query(Item)
                 .filter(

--- a/frontend/src/components/student/ClozeRunner.tsx
+++ b/frontend/src/components/student/ClozeRunner.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import api from "../../services/api";
+
+interface Item {
+    id: string;
+    type: string;
+    stem: string;
+    options?: any;
+    correct_answer: string;
+    explanation?: string;
+}
+
+interface ClozeRunnerProps {
+    uploadId: string;
+    studentId: string;
+    subjectId: string;
+    termId: string;
+    onExit: () => void;
+}
+
+function normalizeText(text: string): string {
+    return text
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .trim()
+        .replace(/\s+/g, " ")
+        .toLowerCase();
+}
+
+function parseAcceptableAnswers(correctAnswer: string): string[] {
+    try {
+        const parsed = JSON.parse(correctAnswer);
+        if (Array.isArray(parsed)) {
+            return parsed.filter((x) => typeof x === "string" || typeof x === "number").map(String);
+        }
+    } catch {
+        // ignore
+    }
+    return [correctAnswer];
+}
+
+export default function ClozeRunner({ uploadId, studentId, subjectId, termId, onExit }: ClozeRunnerProps) {
+    const [items, setItems] = useState<Item[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [sessionId, setSessionId] = useState<string | null>(null);
+    const [activityTypeId, setActivityTypeId] = useState<string | null>(null);
+    const [initError, setInitError] = useState<string>("");
+
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [finished, setFinished] = useState(false);
+    const [answer, setAnswer] = useState("");
+    const [feedback, setFeedback] = useState<{ isCorrect: boolean; text: string } | null>(null);
+    const [questionStartTime, setQuestionStartTime] = useState<Date>(new Date());
+
+    const [sessionFeedbackRating, setSessionFeedbackRating] = useState<number>(5);
+    const [sessionFeedbackText, setSessionFeedbackText] = useState<string>("");
+    const [sessionFeedbackSubmitting, setSessionFeedbackSubmitting] = useState(false);
+    const [sessionFeedbackSubmitted, setSessionFeedbackSubmitted] = useState(false);
+    const [sessionFeedbackError, setSessionFeedbackError] = useState<string>("");
+
+    const currentItem = useMemo(() => items[currentIndex], [items, currentIndex]);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const initSession = async () => {
+            try {
+                setLoading(true);
+                setInitError("");
+                setItems([]);
+                setSessionId(null);
+                setActivityTypeId(null);
+                setCurrentIndex(0);
+                setFinished(false);
+                setAnswer("");
+                setFeedback(null);
+                setSessionFeedbackSubmitted(false);
+                setSessionFeedbackError("");
+
+                const typesRes = await api.get("/activities/activity-types");
+                const clozeType = typesRes.data.find((t: any) => t.code === "CLOZE");
+                if (!clozeType) {
+                    if (!cancelled) setInitError("No se encontró el tipo de actividad CLOZE.");
+                    return;
+                }
+                if (!cancelled) setActivityTypeId(clozeType.id);
+
+                const sessionRes = await api.post("/activities/sessions", {
+                    student_id: studentId,
+                    activity_type_id: clozeType.id,
+                    subject_id: subjectId,
+                    term_id: termId,
+                    topic_id: null,
+                    item_count: 10,
+                    content_upload_id: uploadId,
+                    device_type: "web",
+                });
+                const sid = sessionRes.data.id;
+                if (!cancelled) setSessionId(sid);
+
+                const itemsRes = await api.get(`/activities/sessions/${sid}/items`);
+                if (!cancelled) {
+                    setItems(itemsRes.data);
+                    setQuestionStartTime(new Date());
+                }
+            } catch (err: any) {
+                console.error("Error initializing CLOZE session:", err);
+                const detail = err?.response?.data?.detail;
+                if (!cancelled) {
+                    if (detail === "Not enough permissions") {
+                        setInitError("Necesitas iniciar sesión como estudiante.");
+                    } else if (detail === "No items found for this subject/term") {
+                        setInitError("Este contenido aún no tiene ítems CLOZE. Por ahora usa Quiz.");
+                    } else if (typeof detail === "string" && detail.length > 0) {
+                        setInitError(detail);
+                    } else {
+                        setInitError(err?.message || "No se pudo iniciar la sesión.");
+                    }
+                }
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+
+        initSession();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [uploadId, studentId, subjectId, termId]);
+
+    const submit = async () => {
+        if (!sessionId || !activityTypeId || !currentItem) return;
+        const endTime = new Date();
+        const durationMs = endTime.getTime() - questionStartTime.getTime();
+
+        const acceptable = parseAcceptableAnswers(currentItem.correct_answer).map(normalizeText);
+        const submitted = normalizeText(answer);
+        const isCorrectLocal = acceptable.includes(submitted);
+
+        setFeedback({
+            isCorrect: isCorrectLocal,
+            text: isCorrectLocal
+                ? "Correcto."
+                : `Incorrecto. Respuesta: ${parseAcceptableAnswers(currentItem.correct_answer).join(" / ")}. ${
+                      currentItem.explanation || ""
+                  }`,
+        });
+
+        try {
+            const resp = await api.post(`/activities/sessions/${sessionId}/responses`, {
+                student_id: studentId,
+                item_id: currentItem.id,
+                subject_id: subjectId,
+                term_id: termId,
+                topic_id: null,
+                microconcept_id: null,
+                activity_type_id: activityTypeId,
+                is_correct: isCorrectLocal,
+                duration_ms: durationMs,
+                attempt_number: 1,
+                response_normalized: answer,
+                hint_used: null,
+                difficulty_at_time: null,
+                timestamp_start: questionStartTime.toISOString(),
+                timestamp_end: endTime.toISOString(),
+            });
+
+            if (typeof resp?.data?.is_correct === "boolean") {
+                const backendCorrect = resp.data.is_correct;
+                if (backendCorrect !== isCorrectLocal) {
+                    setFeedback({
+                        isCorrect: backendCorrect,
+                        text: backendCorrect
+                            ? "Correcto."
+                            : `Incorrecto. Respuesta: ${parseAcceptableAnswers(
+                                  currentItem.correct_answer
+                              ).join(" / ")}. ${currentItem.explanation || ""}`,
+                    });
+                }
+            }
+        } catch (err: any) {
+            console.error("Error recording event:", err);
+        }
+    };
+
+    const next = async () => {
+        setAnswer("");
+        setFeedback(null);
+        setQuestionStartTime(new Date());
+        if (currentIndex < items.length - 1) {
+            setCurrentIndex((i) => i + 1);
+            return;
+        }
+        try {
+            await api.post(`/activities/sessions/${sessionId}/end`);
+        } catch (err: any) {
+            console.error("Error ending session:", err);
+        }
+        setFinished(true);
+    };
+
+    const submitSessionFeedback = async () => {
+        if (!sessionId || sessionFeedbackSubmitted) return;
+        setSessionFeedbackSubmitting(true);
+        setSessionFeedbackError("");
+        try {
+            await api.post(`/activities/sessions/${sessionId}/feedback`, {
+                rating: sessionFeedbackRating,
+                text: sessionFeedbackText || null,
+            });
+            setSessionFeedbackSubmitted(true);
+        } catch (err: any) {
+            setSessionFeedbackError(err?.response?.data?.detail || err?.message || "Error enviando feedback");
+        } finally {
+            setSessionFeedbackSubmitting(false);
+        }
+    };
+
+    if (loading) return <p>Cargando cloze...</p>;
+    if (initError) {
+        return (
+            <div className="card" style={{ maxWidth: "600px", margin: "0 auto" }}>
+                <h3 style={{ marginBottom: "0.75rem" }}>No se pudo iniciar la sesión</h3>
+                <p style={{ color: "var(--error)", marginTop: 0 }}>{initError}</p>
+                <button onClick={onExit} className="btn">
+                    Volver
+                </button>
+            </div>
+        );
+    }
+    if (!currentItem) return <p>No hay ítems CLOZE disponibles para este contenido.</p>;
+
+    if (finished) {
+        return (
+            <div className="card" style={{ textAlign: "center" }}>
+                <h3>Actividad Completada</h3>
+                <p style={{ color: "var(--text-secondary)" }}>
+                    Tus métricas se han actualizado automáticamente.
+                </p>
+
+                <div style={{ marginTop: "1.5rem", textAlign: "left" }}>
+                    <h4 style={{ marginTop: 0 }}>Feedback (opcional)</h4>
+                    <label style={{ display: "block", marginBottom: "0.75rem" }}>
+                        Valoración
+                        <select
+                            className="input"
+                            value={sessionFeedbackRating}
+                            onChange={(e) => setSessionFeedbackRating(Number(e.target.value))}
+                            disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                        >
+                            {[1, 2, 3, 4, 5].map((v) => (
+                                <option key={v} value={v}>
+                                    {v}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label style={{ display: "block" }}>
+                        Comentario
+                        <textarea
+                            className="input"
+                            rows={3}
+                            value={sessionFeedbackText}
+                            onChange={(e) => setSessionFeedbackText(e.target.value)}
+                            disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                            placeholder="¿Qué te ha parecido la sesión?"
+                        />
+                    </label>
+                    {sessionFeedbackError && (
+                        <p style={{ color: "var(--error)", marginTop: "0.75rem" }}>{sessionFeedbackError}</p>
+                    )}
+                    {sessionFeedbackSubmitted && (
+                        <p style={{ color: "var(--success)", marginTop: "0.75rem" }}>Feedback enviado.</p>
+                    )}
+                    <button
+                        onClick={submitSessionFeedback}
+                        className="btn btn-secondary"
+                        disabled={sessionFeedbackSubmitting || sessionFeedbackSubmitted}
+                        style={{ marginTop: "0.75rem" }}
+                    >
+                        {sessionFeedbackSubmitting ? "Enviando..." : "Enviar feedback"}
+                    </button>
+                </div>
+
+                <button onClick={onExit} className="btn" style={{ marginTop: "1rem" }}>
+                    Volver al inicio
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="card" style={{ maxWidth: "700px", margin: "0 auto" }}>
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    marginBottom: "1rem",
+                    color: "var(--text-secondary)",
+                }}
+            >
+                <span>Ítem {currentIndex + 1} de {items.length}</span>
+                <span>CLOZE</span>
+            </div>
+
+            <h3 style={{ marginBottom: "1rem" }}>{currentItem.stem}</h3>
+
+            <input
+                className="input"
+                placeholder={currentItem.options?.placeholder || "Respuesta"}
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                disabled={!!feedback}
+            />
+
+            <div style={{ display: "flex", gap: "0.75rem", marginTop: "1.25rem" }}>
+                <button className="btn" onClick={submit} disabled={!!feedback || answer.trim().length === 0}>
+                    Enviar
+                </button>
+                {feedback && (
+                    <button className="btn btn-secondary" onClick={next}>
+                        Siguiente
+                    </button>
+                )}
+            </div>
+
+            {feedback && (
+                <div
+                    style={{
+                        marginTop: "1rem",
+                        padding: "1rem",
+                        backgroundColor: "var(--bg-primary)",
+                        borderRadius: "var(--radius-md)",
+                    }}
+                >
+                    <p style={{ color: feedback.isCorrect ? "var(--success)" : "var(--error)", fontWeight: "bold" }}>
+                        {feedback.text}
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}
+


### PR DESCRIPTION
Sprint 3 Día 5 (Opción A: CLOZE)

- Adds ItemType.CLOZE + Postgres enum migration
- Adds CLOZE grading on /activities/sessions/{id}/responses (tolerant normalization)
- Enables CLOZE session item selection via ActivityType code CLOZE
- Adds seed CLOZE activity type + a demo CLOZE item for test_upload.pdf
- Adds student UI Cloze runner + launch button
- Adds backend test for CLOZE grading