### PR TITLE
feat(tutor): review and toggle items

### DIFF
--- a/backend/app/schemas/item.py
+++ b/backend/app/schemas/item.py
@@ -23,5 +23,11 @@ class ItemCreate(ItemBase):
 class ItemResponse(ItemBase):
     id: uuid.UUID
     content_upload_id: uuid.UUID
+    microconcept_id: uuid.UUID | None = None
+    is_active: bool = True
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ItemActivationUpdate(BaseModel):
+    is_active: bool

--- a/backend/tests/test_item_review.py
+++ b/backend/tests/test_item_review.py
@@ -1,0 +1,207 @@
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.db import SessionLocal
+from app.core.security import get_password_hash
+from app.main import app
+from app.models.activity import ActivityType
+from app.models.content import ContentUpload, ContentUploadType
+from app.models.item import Item, ItemType
+from app.models.microconcept import MicroConcept
+from app.models.role import Role
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import AcademicYear, Term
+from app.models.tutor import Tutor
+from app.models.user import User
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def db_session() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _get_or_create_role(db: Session, name: str) -> Role:
+    role = db.query(Role).filter(Role.name.ilike(name)).first()
+    if role:
+        return role
+    role = Role(name=name)
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    return role
+
+
+def _login(email: str, password: str) -> dict[str, str]:
+    res = client.post("/api/v1/login/access-token", json={"email": email, "password": password})
+    assert res.status_code == 200
+    return {"Authorization": f"Bearer {res.json()['access_token']}"}
+
+
+def test_tutor_can_toggle_item_active_and_student_sees_only_active(db_session: Session):
+    role_tutor = _get_or_create_role(db_session, "tutor")
+    role_student = _get_or_create_role(db_session, "student")
+
+    password = "pw"
+    uid = uuid.uuid4()
+
+    tutor_user = User(
+        id=uuid.uuid4(),
+        email=f"tutor_items_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    student_user = User(
+        id=uuid.uuid4(),
+        email=f"student_items_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add_all([tutor_user, student_user])
+    db_session.flush()
+
+    tutor = Tutor(user_id=tutor_user.id, display_name="Tutor Items")
+    db_session.add(tutor)
+    db_session.flush()
+
+    year = AcademicYear(
+        name=f"2025-2026-items-{uid}",
+        start_date="2025-09-01",
+        end_date="2026-06-30",
+    )
+    db_session.add(year)
+    db_session.flush()
+
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    subject = Subject(name=f"Subject Items {uid}", tutor_id=tutor_user.id)
+    db_session.add_all([term, subject])
+    db_session.flush()
+
+    student = Student(user_id=student_user.id, subject_id=subject.id)
+    db_session.add(student)
+
+    mc = MicroConcept(
+        subject_id=subject.id,
+        term_id=term.id,
+        code="MC-ITEMS",
+        name="MC Items",
+        description="",
+        active=True,
+    )
+    db_session.add(mc)
+    db_session.flush()
+
+    upload = ContentUpload(
+        id=uuid.uuid4(),
+        file_name="items_review.pdf",
+        storage_uri="/test/items_review.pdf",
+        mime_type="application/pdf",
+        upload_type=ContentUploadType.pdf,
+        tutor_id=tutor.id,
+        subject_id=subject.id,
+        term_id=term.id,
+        page_count=1,
+    )
+    db_session.add(upload)
+    db_session.flush()
+
+    inactive_item = Item(
+        id=uuid.uuid4(),
+        content_upload_id=upload.id,
+        microconcept_id=mc.id,
+        type=ItemType.MCQ,
+        stem="Pregunta inactiva",
+        options=["A", "B", "C", "D"],
+        correct_answer="A",
+        explanation="",
+        difficulty=1,
+        is_active=True,
+    )
+    active_item = Item(
+        id=uuid.uuid4(),
+        content_upload_id=upload.id,
+        microconcept_id=mc.id,
+        type=ItemType.MCQ,
+        stem="Pregunta activa",
+        options=["A", "B", "C", "D"],
+        correct_answer="A",
+        explanation="",
+        difficulty=1,
+        is_active=True,
+    )
+    db_session.add_all([inactive_item, active_item])
+
+    quiz_type = db_session.query(ActivityType).filter_by(code="QUIZ").first()
+    if not quiz_type:
+        quiz_type = ActivityType(id=uuid.uuid4(), code="QUIZ", name="Quiz", active=True)
+        db_session.add(quiz_type)
+
+    db_session.commit()
+
+    tutor_headers = _login(tutor_user.email, password)
+    student_headers = _login(student_user.email, password)
+
+    items_tutor_res = client.get(
+        f"/api/v1/content/uploads/{upload.id}/items", headers=tutor_headers
+    )
+    assert items_tutor_res.status_code == 200
+    assert len(items_tutor_res.json()) == 2
+
+    toggle_res = client.patch(
+        f"/api/v1/content/uploads/{upload.id}/items/{inactive_item.id}",
+        json={"is_active": False},
+        headers=tutor_headers,
+    )
+    assert toggle_res.status_code == 200
+    assert toggle_res.json()["is_active"] is False
+
+    items_tutor_res2 = client.get(
+        f"/api/v1/content/uploads/{upload.id}/items", headers=tutor_headers
+    )
+    assert items_tutor_res2.status_code == 200
+    assert any(
+        i["id"] == str(inactive_item.id) and i["is_active"] is False
+        for i in items_tutor_res2.json()
+    )
+
+    items_student_res = client.get(
+        f"/api/v1/content/uploads/{upload.id}/items", headers=student_headers
+    )
+    assert items_student_res.status_code == 200
+    assert all(i["id"] != str(inactive_item.id) for i in items_student_res.json())
+    assert any(i["id"] == str(active_item.id) for i in items_student_res.json())
+
+    session_res = client.post(
+        "/api/v1/activities/sessions",
+        json={
+            "student_id": str(student.id),
+            "activity_type_id": str(quiz_type.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "topic_id": None,
+            "item_count": 1,
+            "content_upload_id": str(upload.id),
+            "device_type": "web",
+        },
+        headers=student_headers,
+    )
+    assert session_res.status_code == 200
+
+    session_id = session_res.json()["id"]
+    session_items_res = client.get(
+        f"/api/v1/activities/sessions/{session_id}/items", headers=student_headers
+    )
+    assert session_items_res.status_code == 200
+    assert len(session_items_res.json()) == 1
+    assert session_items_res.json()[0]["id"] == str(active_item.id)

--- a/frontend/src/components/tutor/UploadItemsManager.tsx
+++ b/frontend/src/components/tutor/UploadItemsManager.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import api from "../../services/api";
+
+interface UploadItemsManagerProps {
+    uploadId: string;
+    onClose: () => void;
+}
+
+interface ItemRow {
+    id: string;
+    type: string;
+    stem: string;
+    is_active?: boolean;
+    microconcept_id?: string | null;
+}
+
+function summarizeStem(stem: string): string {
+    const clean = (stem || "").replace(/\s+/g, " ").trim();
+    if (clean.length <= 90) return clean;
+    return `${clean.slice(0, 87)}...`;
+}
+
+export default function UploadItemsManager({ uploadId, onClose }: UploadItemsManagerProps) {
+    const [items, setItems] = useState<ItemRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [savingId, setSavingId] = useState<string | null>(null);
+
+    const activeCount = useMemo(() => items.filter((i) => i.is_active !== false).length, [items]);
+
+    const fetchItems = async () => {
+        setLoading(true);
+        setError("");
+        try {
+            const res = await api.get(`/content/uploads/${uploadId}/items`);
+            setItems(res.data);
+        } catch (err: any) {
+            const detail = err?.response?.data?.detail;
+            setError(detail || err?.message || "Error cargando ítems");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchItems();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [uploadId]);
+
+    const toggle = async (item: ItemRow) => {
+        const nextActive = item.is_active === false;
+        setSavingId(item.id);
+        setError("");
+        try {
+            const res = await api.patch(`/content/uploads/${uploadId}/items/${item.id}`, {
+                is_active: nextActive,
+            });
+            const updated = res.data;
+            setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
+        } catch (err: any) {
+            const detail = err?.response?.data?.detail;
+            setError(detail || err?.message || "Error actualizando ítem");
+        } finally {
+            setSavingId(null);
+        }
+    };
+
+    return (
+        <div
+            style={{
+                position: "fixed",
+                inset: 0,
+                backgroundColor: "rgba(0,0,0,0.55)",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                padding: "1rem",
+                zIndex: 50,
+            }}
+            onClick={onClose}
+        >
+            <div
+                className="card"
+                style={{ maxWidth: "920px", width: "100%", maxHeight: "85vh", overflow: "auto" }}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <div>
+                        <h3 style={{ margin: 0 }}>Ítems del upload</h3>
+                        <p style={{ margin: "0.25rem 0 0 0", color: "var(--text-secondary)" }}>
+                            Activos: {activeCount} / {items.length}
+                        </p>
+                    </div>
+                    <div style={{ display: "flex", gap: "0.5rem" }}>
+                        <button className="btn btn-secondary" onClick={fetchItems} disabled={loading}>
+                            {loading ? "Cargando..." : "Refrescar"}
+                        </button>
+                        <button className="btn" onClick={onClose}>
+                            Cerrar
+                        </button>
+                    </div>
+                </div>
+
+                {error && (
+                    <p style={{ color: "var(--error)", marginTop: "1rem", fontWeight: 600 }}>{error}</p>
+                )}
+
+                {loading ? (
+                    <p style={{ marginTop: "1rem" }}>Cargando ítems...</p>
+                ) : items.length === 0 ? (
+                    <p style={{ marginTop: "1rem" }}>No hay ítems para este upload.</p>
+                ) : (
+                    <table style={{ width: "100%", borderCollapse: "collapse", marginTop: "1rem" }}>
+                        <thead>
+                            <tr style={{ textAlign: "left", borderBottom: "1px solid var(--border-color)" }}>
+                                <th style={{ padding: "0.5rem" }}>Estado</th>
+                                <th style={{ padding: "0.5rem" }}>Tipo</th>
+                                <th style={{ padding: "0.5rem" }}>Enunciado</th>
+                                <th style={{ padding: "0.5rem", width: "180px" }}>Acción</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {items.map((item) => (
+                                <tr key={item.id} style={{ borderBottom: "1px solid var(--border-color)" }}>
+                                    <td style={{ padding: "0.5rem" }}>
+                                        <span
+                                            style={{
+                                                padding: "0.2rem 0.55rem",
+                                                borderRadius: "var(--radius-sm)",
+                                                backgroundColor:
+                                                    item.is_active === false
+                                                        ? "rgba(255,255,255,0.06)"
+                                                        : "rgba(46, 204, 113, 0.15)",
+                                                color:
+                                                    item.is_active === false
+                                                        ? "var(--text-secondary)"
+                                                        : "var(--success)",
+                                                fontWeight: 700,
+                                                fontSize: "0.85rem",
+                                            }}
+                                        >
+                                            {item.is_active === false ? "Inactivo" : "Activo"}
+                                        </span>
+                                    </td>
+                                    <td style={{ padding: "0.5rem" }}>{item.type}</td>
+                                    <td style={{ padding: "0.5rem" }}>{summarizeStem(item.stem)}</td>
+                                    <td style={{ padding: "0.5rem" }}>
+                                        <button
+                                            className="btn btn-secondary"
+                                            disabled={savingId === item.id}
+                                            onClick={() => toggle(item)}
+                                        >
+                                            {savingId === item.id
+                                                ? "Guardando..."
+                                                : item.is_active === false
+                                                    ? "Activar"
+                                                    : "Desactivar"}
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+
+                <p style={{ marginTop: "1rem", color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+                    Los ítems inactivos no se servirán en nuevas sesiones.
+                </p>
+            </div>
+        </div>
+    );
+}
+

--- a/frontend/src/components/tutor/UploadList.tsx
+++ b/frontend/src/components/tutor/UploadList.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import api from '../../services/api';
 import ProcessButton from './ProcessButton';
+import UploadItemsManager from './UploadItemsManager';
 
 interface Upload {
     id: string;
@@ -20,6 +21,7 @@ export default function UploadList({ refreshSignal }: UploadListProps) {
     const [uploads, setUploads] = useState<Upload[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
+    const [itemsUploadId, setItemsUploadId] = useState<string | null>(null);
 
     const fetchUploads = async () => {
         try {
@@ -67,7 +69,12 @@ export default function UploadList({ refreshSignal }: UploadListProps) {
                             <td style={{ padding: '0.5rem' }}>{upload.upload_type}</td>
                             <td style={{ padding: '0.5rem' }}>{new Date(upload.created_at).toLocaleDateString()}</td>
                             <td style={{ padding: '0.5rem' }}>
-                                <ProcessButton uploadId={upload.id} />
+                                <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                                    <ProcessButton uploadId={upload.id} />
+                                    <button className="btn btn-secondary" onClick={() => setItemsUploadId(upload.id)}>
+                                        Ítems
+                                    </button>
+                                </div>
                             </td>
                         </tr>
                     ))}
@@ -76,6 +83,10 @@ export default function UploadList({ refreshSignal }: UploadListProps) {
             <button onClick={fetchUploads} style={{ marginTop: '1rem', background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer' }}>
                 Refrescar lista
             </button>
+
+            {itemsUploadId && (
+                <UploadItemsManager uploadId={itemsUploadId} onClose={() => setItemsUploadId(null)} />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Sprint 3 Día 6

- Tutor can list all items for an upload (including inactive)
- Student still only sees active items
- Add tutor-only endpoint to activate/deactivate items: PATCH /content/uploads/{upload_id}/items/{item_id}
- Add Tutor UI modal from UploadList to toggle item active state
- Add backend test to ensure deactivated items are not served in sessions