### PR TITLE
docs: document issue linkage workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md (Repositorio)
+
+Este repositorio se gestiona siguiendo el flujo y normas descritos en `CONTRIBUTING.md`.
+
+- Antes de empezar trabajo nuevo, revisa `CONTRIBUTING.md` (ramas, commits, PRs, CI y vinculaciÇün de issues).
+- Si en el futuro aparecen otros `AGENTS.md` en subdirectorios, sus instrucciones aplican al Ã¡rbol de directorios correspondiente.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,3 +141,8 @@ make lint          # Todos los linters
 make lint-fix      # Auto-fix linting
 make db-reset      # Reset DB + migraciones
 ```
+
+## IntegraciÇün con GitHub Issues
+
+- Antes de empezar un sprint, crear las issues del sprint en GitHub (una por dÇða o por entregable), salvo que haya un plan diferente especificado explÇðcitamente en la documentaciÇün.
+- En cada Pull Request, vincular la issue correspondiente en la descripciÇün usando `Fixes #NN` (o `Closes #NN`) para que GitHub la cierre automÇ­ticamente al hacer merge.


### PR DESCRIPTION
Adds contribution workflow guidance:

- Require Fixes #NN/Closes #NN in PR description to auto-close issues.
- Require creating Sprint issues in GitHub before starting a sprint (unless explicitly documented otherwise).
- Adds root AGENTS.md pointing contributors to CONTRIBUTING.md.