### PR TITLE
docs: normalize agents and issue guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,5 +2,5 @@
 
 Este repositorio se gestiona siguiendo el flujo y normas descritos en `CONTRIBUTING.md`.
 
-- Antes de empezar trabajo nuevo, revisa `CONTRIBUTING.md` (ramas, commits, PRs, CI y vinculaciÇün de issues).
-- Si en el futuro aparecen otros `AGENTS.md` en subdirectorios, sus instrucciones aplican al Ã¡rbol de directorios correspondiente.
+- Antes de empezar trabajo nuevo, revisa `CONTRIBUTING.md` (ramas, commits, PRs, CI y vinculacion de issues).
+- Si en el futuro aparecen otros `AGENTS.md` en subdirectorios, sus instrucciones aplican al arbol de directorios correspondiente.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ make lint-fix      # Auto-fix linting
 make db-reset      # Reset DB + migraciones
 ```
 
-## IntegraciÇün con GitHub Issues
+## Integracion con GitHub Issues
 
-- Antes de empezar un sprint, crear las issues del sprint en GitHub (una por dÇða o por entregable), salvo que haya un plan diferente especificado explÇðcitamente en la documentaciÇün.
-- En cada Pull Request, vincular la issue correspondiente en la descripciÇün usando `Fixes #NN` (o `Closes #NN`) para que GitHub la cierre automÇ­ticamente al hacer merge.
+- Antes de empezar un sprint, crear las issues del sprint en GitHub (una por dia o por entregable), salvo que haya un plan diferente especificado explicitamente en la documentacion.
+- En cada Pull Request, vincular la issue correspondiente en la descripcion usando `Fixes #NN` (o `Closes #NN`) para que GitHub la cierre automaticamente al hacer merge.


### PR DESCRIPTION
Normalizes the new contribution guidance to ASCII-only to avoid mojibake in different environments.

- Updates AGENTS.md wording.
- Updates the new GitHub Issues section in CONTRIBUTING.md.