### PR TITLE
feat(grades): add real grades CRUD

### DIFF
--- a/backend/alembic/versions/e8dd5bdddbb8_add_real_grades_tables.py
+++ b/backend/alembic/versions/e8dd5bdddbb8_add_real_grades_tables.py
@@ -1,0 +1,107 @@
+"""add real grades tables
+
+Revision ID: e8dd5bdddbb8
+Revises: 6a2c2e6c0a12
+Create Date: 2025-12-20 12:15:15.686585
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e8dd5bdddbb8"
+down_revision: str | None = "6a2c2e6c0a12"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "real_grades",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("student_id", sa.UUID(), nullable=False),
+        sa.Column("subject_id", sa.UUID(), nullable=False),
+        sa.Column("term_id", sa.UUID(), nullable=False),
+        sa.Column("assessment_date", sa.Date(), nullable=False),
+        sa.Column("grade_value", sa.Numeric(6, 2), nullable=False),
+        sa.Column("grading_scale", sa.String(length=50), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_by_tutor_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["student_id"],
+            ["students.id"],
+            name="real_grades_student_id_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["subject_id"],
+            ["subjects.id"],
+            name="real_grades_subject_id_fkey",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["term_id"],
+            ["terms.id"],
+            name="real_grades_term_id_fkey",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_tutor_id"],
+            ["tutors.id"],
+            name="real_grades_created_by_tutor_id_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_real_grades_student", "real_grades", ["student_id"])
+    op.create_index("idx_real_grades_subject_term", "real_grades", ["subject_id", "term_id"])
+
+    op.create_table(
+        "assessment_scope_tags",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("real_grade_id", sa.UUID(), nullable=False),
+        sa.Column("topic_id", sa.UUID(), nullable=True),
+        sa.Column("microconcept_id", sa.UUID(), nullable=True),
+        sa.Column("weight", sa.Numeric(6, 4), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["real_grade_id"],
+            ["real_grades.id"],
+            name="assessment_scope_tags_real_grade_id_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["topic_id"],
+            ["topics.id"],
+            name="assessment_scope_tags_topic_id_fkey",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["microconcept_id"],
+            ["microconcepts.id"],
+            name="assessment_scope_tags_microconcept_id_fkey",
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_assessment_scope_tags_grade",
+        "assessment_scope_tags",
+        ["real_grade_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_assessment_scope_tags_grade", table_name="assessment_scope_tags")
+    op.drop_table("assessment_scope_tags")
+    op.drop_index("idx_real_grades_subject_term", table_name="real_grades")
+    op.drop_index("idx_real_grades_student", table_name="real_grades")
+    op.drop_table("real_grades")

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -28,6 +28,7 @@ def get_db() -> Iterator[Session]:
 from app.models import (  # noqa: E402, F401, I001
     activity,
     content,
+    grade,
     item,
     knowledge,
     llm_run,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,16 @@ from sqlalchemy.orm import Session
 
 from app.api.v1 import auth, events
 from app.core.db import get_db
-from app.routers import activity, catalog, content, metrics, microconcepts, recommendations, reports
+from app.routers import (
+    activity,
+    catalog,
+    content,
+    grades,
+    metrics,
+    microconcepts,
+    recommendations,
+    reports,
+)
 
 app = FastAPI(
     title="DECIES API",
@@ -28,6 +37,7 @@ app.include_router(microconcepts.router, prefix="/api/v1")
 app.include_router(recommendations.router, prefix="/api/v1")
 app.include_router(reports.router, prefix="/api/v1")
 app.include_router(catalog.router, prefix="/api/v1")
+app.include_router(grades.router, prefix="/api/v1")
 
 # CORS middleware
 app.add_middleware(

--- a/backend/app/models/grade.py
+++ b/backend/app/models/grade.py
@@ -1,0 +1,78 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.db import Base
+
+
+class RealGrade(Base):
+    __tablename__ = "real_grades"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    student_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("students.id", name="real_grades_student_id_fkey", ondelete="CASCADE"),
+        nullable=False,
+    )
+    subject_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("subjects.id", name="real_grades_subject_id_fkey", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    term_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("terms.id", name="real_grades_term_id_fkey", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    assessment_date: Mapped[date] = mapped_column(Date, nullable=False)
+    grade_value: Mapped[float] = mapped_column(Numeric(6, 2), nullable=False)
+    grading_scale: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by_tutor_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tutors.id", name="real_grades_created_by_tutor_id_fkey", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=True
+    )
+
+    scope_tags: Mapped[list["AssessmentScopeTag"]] = relationship(
+        "AssessmentScopeTag",
+        back_populates="real_grade",
+        cascade="all, delete-orphan",
+        order_by="AssessmentScopeTag.id",
+    )
+
+
+class AssessmentScopeTag(Base):
+    __tablename__ = "assessment_scope_tags"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    real_grade_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "real_grades.id", name="assessment_scope_tags_real_grade_id_fkey", ondelete="CASCADE"
+        ),
+        nullable=False,
+    )
+    topic_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("topics.id", name="assessment_scope_tags_topic_id_fkey", ondelete="SET NULL"),
+        nullable=True,
+    )
+    microconcept_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "microconcepts.id",
+            name="assessment_scope_tags_microconcept_id_fkey",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+    weight: Mapped[float | None] = mapped_column(Numeric(6, 4), nullable=True)
+
+    real_grade: Mapped["RealGrade"] = relationship("RealGrade", back_populates="scope_tags")

--- a/backend/app/routers/grades.py
+++ b/backend/app/routers/grades.py
@@ -1,0 +1,286 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session, selectinload
+
+from app.core.db import get_db
+from app.core.deps import get_current_tutor
+from app.models.grade import AssessmentScopeTag, RealGrade
+from app.models.microconcept import MicroConcept
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import Term
+from app.models.topic import Topic
+from app.models.tutor import Tutor
+from app.schemas.grade import (
+    AssessmentScopeTagCreate,
+    AssessmentScopeTagResponse,
+    RealGradeCreate,
+    RealGradeResponse,
+    RealGradeUpdate,
+)
+
+router = APIRouter(prefix="/grades", tags=["grades"])
+
+
+def _require_subject_owned(db: Session, tutor: Tutor, subject_id: uuid.UUID) -> Subject:
+    subject = db.get(Subject, subject_id)
+    if not subject:
+        raise HTTPException(status_code=404, detail="Subject not found")
+    if subject.tutor_id and subject.tutor_id != tutor.user_id:
+        raise HTTPException(status_code=403, detail="Subject not owned by tutor")
+    return subject
+
+
+def _require_student_subject(db: Session, student_id: uuid.UUID, subject_id: uuid.UUID) -> Student:
+    student = db.get(Student, student_id)
+    if not student:
+        raise HTTPException(status_code=404, detail="Student not found")
+    if student.subject_id and student.subject_id != subject_id:
+        raise HTTPException(status_code=403, detail="Student not allowed for subject")
+    return student
+
+
+def _require_term(db: Session, term_id: uuid.UUID) -> Term:
+    term = db.get(Term, term_id)
+    if not term:
+        raise HTTPException(status_code=404, detail="Term not found")
+    return term
+
+
+def _validate_tag_payload(db: Session, grade: RealGrade, payload: AssessmentScopeTagCreate) -> None:
+    if not payload.topic_id and not payload.microconcept_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one of topic_id or microconcept_id is required",
+        )
+
+    if payload.topic_id:
+        topic = db.get(Topic, payload.topic_id)
+        if not topic:
+            raise HTTPException(status_code=404, detail="Topic not found")
+        if topic.subject_id != grade.subject_id:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Topic subject does not match grade subject",
+            )
+        if topic.term_id and topic.term_id != grade.term_id:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Topic term does not match grade term",
+            )
+
+    if payload.microconcept_id:
+        microconcept = db.get(MicroConcept, payload.microconcept_id)
+        if not microconcept:
+            raise HTTPException(status_code=404, detail="Microconcept not found")
+        if microconcept.subject_id != grade.subject_id:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Microconcept subject does not match grade subject",
+            )
+        if microconcept.term_id and microconcept.term_id != grade.term_id:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Microconcept term does not match grade term",
+            )
+
+
+def _require_grade_owned(db: Session, tutor: Tutor, grade_id: uuid.UUID) -> RealGrade:
+    grade = (
+        db.query(RealGrade)
+        .options(selectinload(RealGrade.scope_tags))
+        .filter(RealGrade.id == grade_id)
+        .first()
+    )
+    if not grade:
+        raise HTTPException(status_code=404, detail="Grade not found")
+    if grade.created_by_tutor_id != tutor.id:
+        raise HTTPException(status_code=403, detail="Not allowed")
+    _require_subject_owned(db, tutor, grade.subject_id)
+    return grade
+
+
+@router.post("", response_model=RealGradeResponse, status_code=status.HTTP_201_CREATED)
+def create_real_grade(
+    payload: RealGradeCreate,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    _require_subject_owned(db, current_tutor, payload.subject_id)
+    _require_student_subject(db, payload.student_id, payload.subject_id)
+    _require_term(db, payload.term_id)
+
+    grade = RealGrade(
+        student_id=payload.student_id,
+        subject_id=payload.subject_id,
+        term_id=payload.term_id,
+        assessment_date=payload.assessment_date,
+        grade_value=payload.grade_value,
+        grading_scale=payload.grading_scale,
+        notes=payload.notes,
+        created_by_tutor_id=current_tutor.id,
+    )
+    db.add(grade)
+    db.flush()
+
+    for tag_payload in payload.scope_tags:
+        _validate_tag_payload(db, grade, tag_payload)
+        db.add(
+            AssessmentScopeTag(
+                real_grade_id=grade.id,
+                topic_id=tag_payload.topic_id,
+                microconcept_id=tag_payload.microconcept_id,
+                weight=tag_payload.weight,
+            )
+        )
+
+    db.commit()
+    return _require_grade_owned(db, current_tutor, grade.id)
+
+
+@router.get("", response_model=list[RealGradeResponse])
+def list_real_grades(
+    student_id: uuid.UUID | None = None,
+    subject_id: uuid.UUID | None = None,
+    term_id: uuid.UUID | None = None,
+    limit: int = 50,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    query = (
+        db.query(RealGrade)
+        .options(selectinload(RealGrade.scope_tags))
+        .filter(RealGrade.created_by_tutor_id == current_tutor.id)
+    )
+
+    if student_id:
+        query = query.filter(RealGrade.student_id == student_id)
+    if subject_id:
+        _require_subject_owned(db, current_tutor, subject_id)
+        query = query.filter(RealGrade.subject_id == subject_id)
+    if term_id:
+        _require_term(db, term_id)
+        query = query.filter(RealGrade.term_id == term_id)
+
+    return query.order_by(RealGrade.assessment_date.desc()).limit(limit).all()
+
+
+@router.get("/{grade_id}", response_model=RealGradeResponse)
+def get_real_grade(
+    grade_id: uuid.UUID,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    return _require_grade_owned(db, current_tutor, grade_id)
+
+
+@router.patch("/{grade_id}", response_model=RealGradeResponse)
+def update_real_grade(
+    grade_id: uuid.UUID,
+    payload: RealGradeUpdate,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    grade = _require_grade_owned(db, current_tutor, grade_id)
+
+    if payload.assessment_date is not None:
+        grade.assessment_date = payload.assessment_date
+    if payload.grade_value is not None:
+        grade.grade_value = payload.grade_value
+    if payload.grading_scale is not None:
+        grade.grading_scale = payload.grading_scale
+    if payload.notes is not None:
+        grade.notes = payload.notes
+
+    db.add(grade)
+    db.commit()
+    return _require_grade_owned(db, current_tutor, grade_id)
+
+
+@router.delete("/{grade_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_real_grade(
+    grade_id: uuid.UUID,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    grade = _require_grade_owned(db, current_tutor, grade_id)
+    db.delete(grade)
+    db.commit()
+    return None
+
+
+@router.get("/{grade_id}/tags", response_model=list[AssessmentScopeTagResponse])
+def list_grade_tags(
+    grade_id: uuid.UUID,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    grade = _require_grade_owned(db, current_tutor, grade_id)
+    return grade.scope_tags
+
+
+@router.post(
+    "/{grade_id}/tags",
+    response_model=AssessmentScopeTagResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def add_grade_tag(
+    grade_id: uuid.UUID,
+    payload: AssessmentScopeTagCreate,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    grade = _require_grade_owned(db, current_tutor, grade_id)
+    _validate_tag_payload(db, grade, payload)
+
+    tag = AssessmentScopeTag(
+        real_grade_id=grade.id,
+        topic_id=payload.topic_id,
+        microconcept_id=payload.microconcept_id,
+        weight=payload.weight,
+    )
+    db.add(tag)
+    db.commit()
+    db.refresh(tag)
+    return tag
+
+
+@router.patch("/{grade_id}/tags/{tag_id}", response_model=AssessmentScopeTagResponse)
+def update_grade_tag(
+    grade_id: uuid.UUID,
+    tag_id: uuid.UUID,
+    payload: AssessmentScopeTagCreate,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    grade = _require_grade_owned(db, current_tutor, grade_id)
+    tag = db.query(AssessmentScopeTag).filter_by(id=tag_id, real_grade_id=grade.id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    _validate_tag_payload(db, grade, payload)
+
+    tag.topic_id = payload.topic_id
+    tag.microconcept_id = payload.microconcept_id
+    tag.weight = payload.weight
+    db.add(tag)
+    db.commit()
+    db.refresh(tag)
+    return tag
+
+
+@router.delete("/{grade_id}/tags/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_grade_tag(
+    grade_id: uuid.UUID,
+    tag_id: uuid.UUID,
+    current_tutor: Tutor = Depends(get_current_tutor),
+    db: Session = Depends(get_db),
+):
+    grade = _require_grade_owned(db, current_tutor, grade_id)
+    tag = db.query(AssessmentScopeTag).filter_by(id=tag_id, real_grade_id=grade.id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    db.delete(tag)
+    db.commit()
+    return None

--- a/backend/app/schemas/grade.py
+++ b/backend/app/schemas/grade.py
@@ -1,0 +1,51 @@
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AssessmentScopeTagBase(BaseModel):
+    topic_id: uuid.UUID | None = None
+    microconcept_id: uuid.UUID | None = None
+    weight: float | None = None
+
+
+class AssessmentScopeTagCreate(AssessmentScopeTagBase):
+    pass
+
+
+class AssessmentScopeTagResponse(AssessmentScopeTagBase):
+    id: uuid.UUID
+    real_grade_id: uuid.UUID
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RealGradeBase(BaseModel):
+    student_id: uuid.UUID
+    subject_id: uuid.UUID
+    term_id: uuid.UUID
+    assessment_date: date
+    grade_value: float = Field(..., ge=0)
+    grading_scale: str | None = None
+    notes: str | None = None
+
+
+class RealGradeCreate(RealGradeBase):
+    scope_tags: list[AssessmentScopeTagCreate] = []
+
+
+class RealGradeUpdate(BaseModel):
+    assessment_date: date | None = None
+    grade_value: float | None = Field(default=None, ge=0)
+    grading_scale: str | None = None
+    notes: str | None = None
+
+
+class RealGradeResponse(RealGradeBase):
+    id: uuid.UUID
+    created_by_tutor_id: uuid.UUID
+    created_at: datetime | None = None
+    scope_tags: list[AssessmentScopeTagResponse] = []
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_real_grades.py
+++ b/backend/tests/test_real_grades.py
@@ -1,0 +1,225 @@
+import uuid
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.db import SessionLocal
+from app.core.security import get_password_hash
+from app.main import app
+from app.models.microconcept import MicroConcept
+from app.models.role import Role
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import AcademicYear, Term
+from app.models.topic import Topic
+from app.models.tutor import Tutor
+from app.models.user import User
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def db_session() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _ensure_role(db: Session, name: str) -> Role:
+    role = db.query(Role).filter_by(name=name).first()
+    if not role:
+        role = Role(name=name)
+        db.add(role)
+        db.commit()
+    return role
+
+
+def _login(email: str, password: str) -> dict[str, str]:
+    res = client.post("/api/v1/login/access-token", json={"email": email, "password": password})
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_real_grades_crud_and_tags(db_session: Session):
+    uid = uuid.uuid4()
+    role_tutor = _ensure_role(db_session, "Tutor")
+    role_student = _ensure_role(db_session, "Student")
+
+    password = "pw"
+    tutor_user = User(
+        id=uuid.uuid4(),
+        email=f"t_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    student_user = User(
+        id=uuid.uuid4(),
+        email=f"s_{uid}@example.com",
+        hashed_password="x",
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add_all([tutor_user, student_user])
+    db_session.flush()
+
+    tutor = Tutor(user_id=tutor_user.id, display_name="Tutor Grades")
+    subject = Subject(name=f"Math Grades {uid}", tutor_id=tutor_user.id)
+    student = Student(user_id=student_user.id, subject_id=subject.id)
+    db_session.add_all([tutor, subject, student])
+    db_session.flush()
+
+    year = AcademicYear(
+        name=f"2025-2026-{uid}",
+        start_date=date(2025, 9, 1),
+        end_date=date(2026, 6, 30),
+    )
+    db_session.add(year)
+    db_session.flush()
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    db_session.add(term)
+    db_session.flush()
+
+    topic = Topic(subject_id=subject.id, term_id=term.id, name="Topic A")
+    microconcept = MicroConcept(
+        subject_id=subject.id, term_id=term.id, topic_id=topic.id, name="MC A"
+    )
+    db_session.add_all([topic, microconcept])
+    db_session.commit()
+
+    headers = _login(tutor_user.email, password)
+
+    create_res = client.post(
+        "/api/v1/grades",
+        json={
+            "student_id": str(student.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "assessment_date": "2025-12-01",
+            "grade_value": 7.5,
+            "grading_scale": "0-10",
+            "notes": "Buen progreso.",
+            "scope_tags": [
+                {"topic_id": str(topic.id), "microconcept_id": str(microconcept.id), "weight": 1.0}
+            ],
+        },
+        headers=headers,
+    )
+    assert create_res.status_code == 201
+    created = create_res.json()
+    assert created["student_id"] == str(student.id)
+    assert created["created_by_tutor_id"] == str(tutor.id)
+    assert len(created["scope_tags"]) == 1
+
+    grade_id = created["id"]
+    tag_id = created["scope_tags"][0]["id"]
+
+    list_res = client.get(
+        "/api/v1/grades",
+        params={
+            "student_id": str(student.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+        },
+        headers=headers,
+    )
+    assert list_res.status_code == 200
+    assert any(g["id"] == grade_id for g in list_res.json())
+
+    patch_res = client.patch(
+        f"/api/v1/grades/{grade_id}",
+        json={"grade_value": 8.25, "notes": "Mejorando."},
+        headers=headers,
+    )
+    assert patch_res.status_code == 200
+    assert patch_res.json()["grade_value"] == 8.25
+
+    tags_res = client.get(f"/api/v1/grades/{grade_id}/tags", headers=headers)
+    assert tags_res.status_code == 200
+    assert len(tags_res.json()) == 1
+
+    tag_patch = client.patch(
+        f"/api/v1/grades/{grade_id}/tags/{tag_id}",
+        json={"topic_id": str(topic.id), "microconcept_id": str(microconcept.id), "weight": 0.5},
+        headers=headers,
+    )
+    assert tag_patch.status_code == 200
+    assert tag_patch.json()["weight"] == 0.5
+
+    tag_del = client.delete(f"/api/v1/grades/{grade_id}/tags/{tag_id}", headers=headers)
+    assert tag_del.status_code == 204
+
+    del_res = client.delete(f"/api/v1/grades/{grade_id}", headers=headers)
+    assert del_res.status_code == 204
+
+
+def test_real_grades_rbac(db_session: Session):
+    uid = uuid.uuid4()
+    role_tutor = _ensure_role(db_session, "Tutor")
+    role_student = _ensure_role(db_session, "Student")
+
+    password = "pw"
+    tutor_user_a = User(
+        id=uuid.uuid4(),
+        email=f"ta_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    tutor_user_b = User(
+        id=uuid.uuid4(),
+        email=f"tb_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    student_user = User(
+        id=uuid.uuid4(),
+        email=f"s_{uid}@example.com",
+        hashed_password="x",
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add_all([tutor_user_a, tutor_user_b, student_user])
+    db_session.flush()
+
+    tutor_a = Tutor(user_id=tutor_user_a.id, display_name="Tutor A")
+    tutor_b = Tutor(user_id=tutor_user_b.id, display_name="Tutor B")
+    subject = Subject(name=f"Subject {uid}", tutor_id=tutor_user_a.id)
+    student = Student(user_id=student_user.id, subject_id=subject.id)
+    db_session.add_all([tutor_a, tutor_b, subject, student])
+    db_session.flush()
+
+    year = AcademicYear(
+        name=f"2025-2026-{uid}",
+        start_date=date(2025, 9, 1),
+        end_date=date(2026, 6, 30),
+    )
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    db_session.add_all([year, term])
+    db_session.commit()
+
+    headers_a = _login(tutor_user_a.email, password)
+    headers_b = _login(tutor_user_b.email, password)
+
+    create_res = client.post(
+        "/api/v1/grades",
+        json={
+            "student_id": str(student.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "assessment_date": "2025-12-01",
+            "grade_value": 5.0,
+        },
+        headers=headers_a,
+    )
+    assert create_res.status_code == 201
+    grade_id = create_res.json()["id"]
+
+    forbidden = client.get(f"/api/v1/grades/{grade_id}", headers=headers_b)
+    assert forbidden.status_code == 403


### PR DESCRIPTION
Implements Sprint 4 Day 1 real grades backend.

- Adds eal_grades + ssessment_scope_tags tables (Alembic migration).
- Adds tutor-only CRUD API under /api/v1/grades with scope-tag management and validations.
- Adds tests covering CRUD + RBAC.

Fixes #56