### PR TITLE
feat(tutor): add real grades UI

### DIFF
--- a/backend/app/schemas/catalog.py
+++ b/backend/app/schemas/catalog.py
@@ -30,3 +30,13 @@ class StudentSummary(BaseModel):
     enrollment_date: datetime | None = None
     email: str | None = None
     full_name: str | None = None
+
+
+class TopicSummary(BaseModel):
+    id: uuid.UUID
+    subject_id: uuid.UUID
+    term_id: uuid.UUID | None = None
+    code: str | None = None
+    name: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_catalog_topics.py
+++ b/backend/tests/test_catalog_topics.py
@@ -1,0 +1,162 @@
+import uuid
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.db import SessionLocal
+from app.core.security import get_password_hash
+from app.main import app
+from app.models.role import Role
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import AcademicYear, Term
+from app.models.topic import Topic
+from app.models.tutor import Tutor
+from app.models.user import User
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def db_session() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _ensure_role(db: Session, name: str) -> Role:
+    role = db.query(Role).filter_by(name=name).first()
+    if not role:
+        role = Role(name=name)
+        db.add(role)
+        db.commit()
+    return role
+
+
+def _login(email: str, password: str) -> dict[str, str]:
+    res = client.post("/api/v1/login/access-token", json={"email": email, "password": password})
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_catalog_topics_tutor_scoping(db_session: Session):
+    uid = uuid.uuid4()
+    role_tutor = _ensure_role(db_session, "Tutor")
+
+    password = "pw"
+    tutor_user_a = User(
+        id=uuid.uuid4(),
+        email=f"ta_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    tutor_user_b = User(
+        id=uuid.uuid4(),
+        email=f"tb_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    db_session.add_all([tutor_user_a, tutor_user_b])
+    db_session.flush()
+
+    tutor_a = Tutor(user_id=tutor_user_a.id, display_name="Tutor A")
+    tutor_b = Tutor(user_id=tutor_user_b.id, display_name="Tutor B")
+    subject_a = Subject(name=f"Sub A {uid}", tutor_id=tutor_user_a.id)
+    subject_b = Subject(name=f"Sub B {uid}", tutor_id=tutor_user_b.id)
+    db_session.add_all([tutor_a, tutor_b, subject_a, subject_b])
+    db_session.flush()
+
+    year = AcademicYear(
+        name=f"2025-2026-{uid}",
+        start_date=date(2025, 9, 1),
+        end_date=date(2026, 6, 30),
+    )
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    db_session.add_all([year, term])
+    db_session.flush()
+
+    topic_a = Topic(subject_id=subject_a.id, term_id=term.id, name="Topic A", order_index=1)
+    topic_b = Topic(subject_id=subject_b.id, term_id=term.id, name="Topic B", order_index=1)
+    db_session.add_all([topic_a, topic_b])
+    db_session.commit()
+
+    headers_a = _login(tutor_user_a.email, password)
+
+    ok = client.get(
+        "/api/v1/catalog/topics",
+        params={"mine": True, "subject_id": str(subject_a.id), "term_id": str(term.id)},
+        headers=headers_a,
+    )
+    assert ok.status_code == 200
+    assert any(t["id"] == str(topic_a.id) for t in ok.json())
+    assert all(t["subject_id"] == str(subject_a.id) for t in ok.json())
+
+    forbidden = client.get(
+        "/api/v1/catalog/topics",
+        params={"mine": True, "subject_id": str(subject_b.id)},
+        headers=headers_a,
+    )
+    assert forbidden.status_code == 403
+
+
+def test_catalog_topics_student_scoping(db_session: Session):
+    uid = uuid.uuid4()
+    role_student = _ensure_role(db_session, "Student")
+    role_tutor = _ensure_role(db_session, "Tutor")
+
+    password = "pw"
+    tutor_user = User(
+        id=uuid.uuid4(),
+        email=f"t_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    student_user = User(
+        id=uuid.uuid4(),
+        email=f"s_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add_all([tutor_user, student_user])
+    db_session.flush()
+
+    tutor = Tutor(user_id=tutor_user.id, display_name="Tutor")
+    subject = Subject(name=f"Sub {uid}", tutor_id=tutor_user.id)
+    db_session.add_all([tutor, subject])
+    db_session.flush()
+    student = Student(user_id=student_user.id, subject_id=subject.id)
+    db_session.add(student)
+    db_session.flush()
+
+    year = AcademicYear(
+        name=f"2025-2026-{uid}",
+        start_date=date(2025, 9, 1),
+        end_date=date(2026, 6, 30),
+    )
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    db_session.add_all([year, term])
+    db_session.flush()
+
+    topic = Topic(subject_id=subject.id, term_id=term.id, name="Topic A", order_index=1)
+    other_subject = Subject(name=f"Sub other {uid}", tutor_id=tutor_user.id)
+    db_session.add(other_subject)
+    db_session.flush()
+    other_topic = Topic(subject_id=other_subject.id, term_id=term.id, name="Topic B", order_index=1)
+    db_session.add_all([topic, other_topic])
+    db_session.commit()
+
+    headers = _login(student_user.email, password)
+    res = client.get("/api/v1/catalog/topics", headers=headers)
+    assert res.status_code == 200
+    topics = res.json()
+    assert any(t["id"] == str(topic.id) for t in topics)
+    assert all(t["subject_id"] == str(subject.id) for t in topics)

--- a/frontend/src/app/tutor/page.tsx
+++ b/frontend/src/app/tutor/page.tsx
@@ -8,11 +8,12 @@ import MetricsDashboard from '../../components/tutor/MetricsDashboard';
 import RecommendationList from '../../components/tutor/RecommendationList';
 import TutorReportPanel from '../../components/tutor/TutorReportPanel';
 import MicroconceptManager from '../../components/tutor/MicroconceptManager';
+import RealGradesPanel from '../../components/tutor/RealGradesPanel';
 import { AuthMe } from '../../services/auth';
 import { fetchStudents, fetchSubjects, fetchTerms, StudentSummary, SubjectSummary, TermSummary } from '../../services/catalog';
 
 export default function TutorPage() {
-    const [activeTab, setActiveTab] = useState<'content' | 'metrics' | 'recommendations' | 'reports' | 'microconcepts'>('content');
+    const [activeTab, setActiveTab] = useState<'content' | 'metrics' | 'recommendations' | 'reports' | 'microconcepts' | 'grades'>('content');
 
     const [me, setMe] = useState<AuthMe | null>(null);
     const [subjects, setSubjects] = useState<SubjectSummary[]>([]);
@@ -175,6 +176,12 @@ export default function TutorPage() {
                         >
                             Microconceptos
                         </button>
+                        <button
+                            onClick={() => setActiveTab('grades')}
+                            style={getTabStyle('grades')}
+                        >
+                            Calificaciones
+                        </button>
                     </div>
 
                     {/* Content */}
@@ -239,6 +246,18 @@ export default function TutorPage() {
                             />
                         ) : (
                             <p>Selecciona asignatura y trimestre para gestionar microconceptos.</p>
+                        )
+                    )}
+
+                    {activeTab === 'grades' && (
+                        selectedStudentId && selectedSubjectId && selectedTermId ? (
+                            <RealGradesPanel
+                                studentId={selectedStudentId}
+                                subjectId={selectedSubjectId}
+                                termId={selectedTermId}
+                            />
+                        ) : (
+                            <p>Selecciona contexto para ver calificaciones.</p>
                         )
                     )}
                 </>

--- a/frontend/src/components/tutor/MicroconceptManager.tsx
+++ b/frontend/src/components/tutor/MicroconceptManager.tsx
@@ -143,8 +143,10 @@ export default function MicroconceptManager({ subjectId, termId }: MicroconceptM
             const currentIds = new Set(current.map((e) => e.prerequisite_microconcept_id));
             const desiredIds = new Set(prereqSelection);
 
-            const toAdd = [...desiredIds].filter((id) => !currentIds.has(id));
-            const toRemove = [...currentIds].filter((id) => !desiredIds.has(id));
+            const toAdd = prereqSelection.filter((id) => !currentIds.has(id));
+            const toRemove = current
+                .filter((edge) => !desiredIds.has(edge.prerequisite_microconcept_id))
+                .map((edge) => edge.prerequisite_microconcept_id);
 
             if (toAdd.length > 0) {
                 await Promise.all(toAdd.map((id) => addMicroconceptPrerequisite(prereqOpenId, id)));

--- a/frontend/src/components/tutor/RealGradesPanel.tsx
+++ b/frontend/src/components/tutor/RealGradesPanel.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { fetchMicroconcepts, MicroConcept } from "../../services/microconcepts";
+import { fetchTopics, TopicSummary } from "../../services/catalog";
+import {
+    addGradeTag,
+    AssessmentScopeTagCreatePayload,
+    createGrade,
+    deleteGrade,
+    deleteGradeTag,
+    fetchGrades,
+    RealGrade,
+    updateGrade,
+} from "../../services/grades";
+
+interface RealGradesPanelProps {
+    studentId: string;
+    subjectId: string;
+    termId: string;
+}
+
+type Mode = "create" | "edit";
+
+export default function RealGradesPanel({ studentId, subjectId, termId }: RealGradesPanelProps) {
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const [grades, setGrades] = useState<RealGrade[]>([]);
+    const [selectedGradeId, setSelectedGradeId] = useState<string | null>(null);
+
+    const [topics, setTopics] = useState<TopicSummary[]>([]);
+    const [microconcepts, setMicroconcepts] = useState<MicroConcept[]>([]);
+
+    const selectedGrade = useMemo(
+        () => grades.find((g) => g.id === selectedGradeId) ?? null,
+        [grades, selectedGradeId]
+    );
+
+    const [mode, setMode] = useState<Mode>("create");
+    const [assessmentDate, setAssessmentDate] = useState<string>("");
+    const [gradeValue, setGradeValue] = useState<string>("");
+    const [gradingScale, setGradingScale] = useState<string>("");
+    const [notes, setNotes] = useState<string>("");
+
+    const [draftTags, setDraftTags] = useState<AssessmentScopeTagCreatePayload[]>([]);
+    const [tagTopicId, setTagTopicId] = useState<string>("");
+    const [tagMicroconceptId, setTagMicroconceptId] = useState<string>("");
+    const [tagWeight, setTagWeight] = useState<string>("");
+
+    const topicById = useMemo(() => new Map(topics.map((t) => [t.id, t])), [topics]);
+    const microconceptById = useMemo(
+        () => new Map(microconcepts.map((m) => [m.id, m])),
+        [microconcepts]
+    );
+
+    const resetForm = () => {
+        setMode("create");
+        setSelectedGradeId(null);
+        setAssessmentDate("");
+        setGradeValue("");
+        setGradingScale("");
+        setNotes("");
+        setDraftTags([]);
+        setTagTopicId("");
+        setTagMicroconceptId("");
+        setTagWeight("");
+        setError(null);
+    };
+
+    const load = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const [gradesData, topicsData, microconceptsData] = await Promise.all([
+                fetchGrades({ studentId, subjectId, termId }),
+                fetchTopics({ mine: true, subjectId, termId }),
+                fetchMicroconcepts({ subjectId, termId }),
+            ]);
+            setGrades(gradesData);
+            setTopics(topicsData);
+            setMicroconcepts(microconceptsData);
+        } catch (err: any) {
+            setError(err?.response?.data?.detail || err.message || "Error cargando calificaciones");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        resetForm();
+        if (!studentId || !subjectId || !termId) return;
+        load();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [studentId, subjectId, termId]);
+
+    useEffect(() => {
+        if (!selectedGrade) return;
+        setMode("edit");
+        setAssessmentDate(selectedGrade.assessment_date ?? "");
+        setGradeValue(String(selectedGrade.grade_value ?? ""));
+        setGradingScale(selectedGrade.grading_scale ?? "");
+        setNotes(selectedGrade.notes ?? "");
+        setDraftTags([]);
+        setTagTopicId("");
+        setTagMicroconceptId("");
+        setTagWeight("");
+        setError(null);
+    }, [selectedGrade]);
+
+    const addDraftTag = () => {
+        setError(null);
+        if (!tagTopicId && !tagMicroconceptId) {
+            setError("Selecciona un topic o un microconcepto para el tag.");
+            return;
+        }
+        const weight = tagWeight ? Number(tagWeight) : null;
+        if (tagWeight && Number.isNaN(weight)) {
+            setError("El peso debe ser un número válido.");
+            return;
+        }
+        setDraftTags((prev) => [
+            ...prev,
+            {
+                topic_id: tagTopicId || null,
+                microconcept_id: tagMicroconceptId || null,
+                weight,
+            },
+        ]);
+        setTagTopicId("");
+        setTagMicroconceptId("");
+        setTagWeight("");
+    };
+
+    const removeDraftTag = (index: number) => {
+        setDraftTags((prev) => prev.filter((_, i) => i !== index));
+    };
+
+    const onSubmit = async () => {
+        setSaving(true);
+        setError(null);
+        try {
+            if (mode === "create") {
+                const created = await createGrade({
+                    student_id: studentId,
+                    subject_id: subjectId,
+                    term_id: termId,
+                    assessment_date: assessmentDate,
+                    grade_value: Number(gradeValue),
+                    grading_scale: gradingScale || null,
+                    notes: notes || null,
+                    scope_tags: draftTags,
+                });
+                setGrades((prev) => [created, ...prev]);
+                resetForm();
+            } else if (selectedGrade) {
+                const updated = await updateGrade(selectedGrade.id, {
+                    assessment_date: assessmentDate,
+                    grade_value: Number(gradeValue),
+                    grading_scale: gradingScale || null,
+                    notes: notes || null,
+                });
+                setGrades((prev) => prev.map((g) => (g.id === updated.id ? updated : g)));
+            }
+        } catch (err: any) {
+            setError(err?.response?.data?.detail || err.message || "Error guardando calificación");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const onDeleteGrade = async (gradeId: string) => {
+        if (!confirm("¿Borrar esta calificación?")) return;
+        setSaving(true);
+        setError(null);
+        try {
+            await deleteGrade(gradeId);
+            setGrades((prev) => prev.filter((g) => g.id !== gradeId));
+            if (selectedGradeId === gradeId) resetForm();
+        } catch (err: any) {
+            setError(err?.response?.data?.detail || err.message || "Error borrando calificación");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const onAddTagToGrade = async () => {
+        if (!selectedGrade) return;
+        setSaving(true);
+        setError(null);
+        try {
+            if (!tagTopicId && !tagMicroconceptId) {
+                setError("Selecciona un topic o un microconcepto para el tag.");
+                return;
+            }
+            const weight = tagWeight ? Number(tagWeight) : null;
+            if (tagWeight && Number.isNaN(weight)) {
+                setError("El peso debe ser un número válido.");
+                return;
+            }
+            const createdTag = await addGradeTag(selectedGrade.id, {
+                topic_id: tagTopicId || null,
+                microconcept_id: tagMicroconceptId || null,
+                weight,
+            });
+            setGrades((prev) =>
+                prev.map((g) =>
+                    g.id === selectedGrade.id ? { ...g, scope_tags: [...g.scope_tags, createdTag] } : g
+                )
+            );
+            setTagTopicId("");
+            setTagMicroconceptId("");
+            setTagWeight("");
+        } catch (err: any) {
+            setError(err?.response?.data?.detail || err.message || "Error añadiendo tag");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const onDeleteTag = async (tagId: string) => {
+        if (!selectedGrade) return;
+        setSaving(true);
+        setError(null);
+        try {
+            await deleteGradeTag(selectedGrade.id, tagId);
+            setGrades((prev) =>
+                prev.map((g) =>
+                    g.id === selectedGrade.id
+                        ? { ...g, scope_tags: g.scope_tags.filter((t) => t.id !== tagId) }
+                        : g
+                )
+            );
+        } catch (err: any) {
+            setError(err?.response?.data?.detail || err.message || "Error borrando tag");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const canSubmit = assessmentDate && gradeValue.trim() !== "" && !Number.isNaN(Number(gradeValue));
+
+    if (loading) return <p>Cargando calificaciones...</p>;
+
+    return (
+        <div style={{ display: "grid", gap: "1.5rem" }}>
+            <div className="card" style={{ padding: "1.25rem" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", flexWrap: "wrap" }}>
+                    <div>
+                        <h3 style={{ margin: 0 }}>Calificaciones reales</h3>
+                        <p style={{ margin: "0.25rem 0 0", color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+                            Registra examenes/entregas y su alcance por topic o microconcepto.
+                        </p>
+                    </div>
+                    <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+                        <button className="btn btn-secondary" onClick={load} disabled={saving}>
+                            Refrescar
+                        </button>
+                        <button className="btn btn-secondary" onClick={resetForm} disabled={saving}>
+                            Nueva
+                        </button>
+                    </div>
+                </div>
+
+                {error && <p style={{ marginTop: "1rem", color: "var(--error)" }}>{error}</p>}
+
+                {grades.length === 0 ? (
+                    <p style={{ marginTop: "1rem", color: "var(--text-secondary)" }}>
+                        Todavia no hay calificaciones registradas para este contexto.
+                    </p>
+                ) : (
+                    <div style={{ marginTop: "1rem", overflowX: "auto" }}>
+                        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                            <thead>
+                                <tr style={{ textAlign: "left", color: "var(--text-secondary)" }}>
+                                    <th style={{ padding: "0.5rem" }}>Fecha</th>
+                                    <th style={{ padding: "0.5rem" }}>Nota</th>
+                                    <th style={{ padding: "0.5rem" }}>Escala</th>
+                                    <th style={{ padding: "0.5rem" }}>Tags</th>
+                                    <th style={{ padding: "0.5rem" }}>Acciones</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {grades.map((grade) => {
+                                    const isSelected = grade.id === selectedGradeId;
+                                    return (
+                                        <tr
+                                            key={grade.id}
+                                            style={{
+                                                borderTop: "1px solid var(--border-color)",
+                                                background: isSelected ? "rgba(124, 58, 237, 0.08)" : "transparent",
+                                                cursor: "pointer",
+                                            }}
+                                            onClick={() => setSelectedGradeId(grade.id)}
+                                        >
+                                            <td style={{ padding: "0.5rem" }}>{grade.assessment_date}</td>
+                                            <td style={{ padding: "0.5rem" }}>{grade.grade_value}</td>
+                                            <td style={{ padding: "0.5rem" }}>{grade.grading_scale || "-"}</td>
+                                            <td style={{ padding: "0.5rem" }}>{grade.scope_tags?.length || 0}</td>
+                                            <td style={{ padding: "0.5rem", display: "flex", gap: "0.5rem" }}>
+                                                <button
+                                                    className="btn btn-secondary"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        setSelectedGradeId(grade.id);
+                                                    }}
+                                                >
+                                                    Editar
+                                                </button>
+                                                <button
+                                                    className="btn btn-secondary"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        onDeleteGrade(grade.id);
+                                                    }}
+                                                    disabled={saving}
+                                                >
+                                                    Borrar
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+
+            <div className="card" style={{ padding: "1.25rem" }}>
+                <h3 style={{ marginTop: 0 }}>{mode === "create" ? "Nueva calificacion" : "Editar calificacion"}</h3>
+
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: "1rem" }}>
+                    <label>
+                        Fecha
+                        <input
+                            className="input"
+                            type="date"
+                            value={assessmentDate}
+                            onChange={(e) => setAssessmentDate(e.target.value)}
+                        />
+                    </label>
+                    <label>
+                        Nota
+                        <input
+                            className="input"
+                            type="number"
+                            step="0.01"
+                            value={gradeValue}
+                            onChange={(e) => setGradeValue(e.target.value)}
+                            placeholder="7.5"
+                        />
+                    </label>
+                    <label>
+                        Escala (opcional)
+                        <input
+                            className="input"
+                            value={gradingScale}
+                            onChange={(e) => setGradingScale(e.target.value)}
+                            placeholder="0-10"
+                        />
+                    </label>
+                </div>
+
+                <label style={{ display: "block", marginTop: "1rem" }}>
+                    Notas (opcional)
+                    <textarea
+                        className="input"
+                        style={{ minHeight: "90px" }}
+                        value={notes}
+                        onChange={(e) => setNotes(e.target.value)}
+                        placeholder="Comentario breve..."
+                    />
+                </label>
+
+                <div style={{ marginTop: "1rem" }}>
+                    <h4 style={{ margin: "0 0 0.5rem" }}>Tags de alcance</h4>
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: "1rem" }}>
+                        <label>
+                            Topic (opcional)
+                            <select className="input" value={tagTopicId} onChange={(e) => setTagTopicId(e.target.value)}>
+                                <option value="">(ninguno)</option>
+                                {topics.map((t) => (
+                                    <option key={t.id} value={t.id}>
+                                        {t.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                        <label>
+                            Microconcepto (opcional)
+                            <select
+                                className="input"
+                                value={tagMicroconceptId}
+                                onChange={(e) => setTagMicroconceptId(e.target.value)}
+                            >
+                                <option value="">(ninguno)</option>
+                                {microconcepts
+                                    .filter((m) => m.active)
+                                    .map((m) => (
+                                        <option key={m.id} value={m.id}>
+                                            {m.name}
+                                        </option>
+                                    ))}
+                            </select>
+                        </label>
+                        <label>
+                            Peso (opcional)
+                            <input
+                                className="input"
+                                type="number"
+                                step="0.0001"
+                                value={tagWeight}
+                                onChange={(e) => setTagWeight(e.target.value)}
+                                placeholder="1.0"
+                            />
+                        </label>
+                    </div>
+
+                    {mode === "create" ? (
+                        <>
+                            <div style={{ marginTop: "0.75rem", display: "flex", gap: "0.75rem" }}>
+                                <button className="btn btn-secondary" onClick={addDraftTag} disabled={saving}>
+                                    Añadir tag a la nueva calificacion
+                                </button>
+                            </div>
+                            {draftTags.length > 0 && (
+                                <div style={{ marginTop: "0.75rem", display: "grid", gap: "0.5rem" }}>
+                                    {draftTags.map((t, idx) => (
+                                        <div
+                                            key={`${t.topic_id}-${t.microconcept_id}-${idx}`}
+                                            style={{
+                                                display: "flex",
+                                                justifyContent: "space-between",
+                                                alignItems: "center",
+                                                padding: "0.5rem 0.75rem",
+                                                background: "var(--bg-secondary)",
+                                                borderRadius: "var(--radius-md)",
+                                            }}
+                                        >
+                                            <div style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+                                                {(t.topic_id && `Topic: ${topicById.get(t.topic_id)?.name ?? t.topic_id}`) ||
+                                                    "(sin topic)"}
+                                                {" · "}
+                                                {(t.microconcept_id &&
+                                                    `Microconcepto: ${microconceptById.get(t.microconcept_id)?.name ?? t.microconcept_id}`) ||
+                                                    "(sin microconcepto)"}
+                                                {t.weight != null ? ` · peso ${t.weight}` : ""}
+                                            </div>
+                                            <button className="btn btn-secondary" onClick={() => removeDraftTag(idx)}>
+                                                Quitar
+                                            </button>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    ) : (
+                        <>
+                            <div style={{ marginTop: "0.75rem", display: "flex", gap: "0.75rem" }}>
+                                <button className="btn btn-secondary" onClick={onAddTagToGrade} disabled={saving || !selectedGrade}>
+                                    Añadir tag a esta calificacion
+                                </button>
+                            </div>
+
+                            {selectedGrade?.scope_tags?.length ? (
+                                <div style={{ marginTop: "0.75rem", display: "grid", gap: "0.5rem" }}>
+                                    {selectedGrade.scope_tags.map((t) => (
+                                        <div
+                                            key={t.id}
+                                            style={{
+                                                display: "flex",
+                                                justifyContent: "space-between",
+                                                alignItems: "center",
+                                                padding: "0.5rem 0.75rem",
+                                                background: "var(--bg-secondary)",
+                                                borderRadius: "var(--radius-md)",
+                                            }}
+                                        >
+                                            <div style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+                                                {(t.topic_id && `Topic: ${topicById.get(t.topic_id)?.name ?? t.topic_id}`) ||
+                                                    "(sin topic)"}
+                                                {" · "}
+                                                {(t.microconcept_id &&
+                                                    `Microconcepto: ${microconceptById.get(t.microconcept_id)?.name ?? t.microconcept_id}`) ||
+                                                    "(sin microconcepto)"}
+                                                {t.weight != null ? ` · peso ${t.weight}` : ""}
+                                            </div>
+                                            <button className="btn btn-secondary" onClick={() => onDeleteTag(t.id)} disabled={saving}>
+                                                Borrar
+                                            </button>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p style={{ marginTop: "0.75rem", color: "var(--text-secondary)" }}>
+                                    Esta calificacion aun no tiene tags.
+                                </p>
+                            )}
+                        </>
+                    )}
+                </div>
+
+                <div style={{ marginTop: "1.25rem", display: "flex", gap: "0.75rem", alignItems: "center" }}>
+                    <button className="btn" onClick={onSubmit} disabled={saving || !canSubmit}>
+                        {saving ? "Guardando..." : mode === "create" ? "Crear" : "Guardar"}
+                    </button>
+                    {mode === "edit" && (
+                        <button className="btn btn-secondary" onClick={resetForm} disabled={saving}>
+                            Cancelar
+                        </button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/services/catalog.ts
+++ b/frontend/src/services/catalog.ts
@@ -23,6 +23,14 @@ export interface StudentSummary {
     full_name?: string | null;
 }
 
+export interface TopicSummary {
+    id: string;
+    subject_id: string;
+    term_id?: string | null;
+    code?: string | null;
+    name: string;
+}
+
 export async function fetchSubjects(mine = true): Promise<SubjectSummary[]> {
     const res = await api.get('/catalog/subjects', { params: { mine } });
     return res.data as SubjectSummary[];
@@ -40,3 +48,17 @@ export async function fetchStudents(mine = true, subjectId?: string): Promise<St
     return res.data as StudentSummary[];
 }
 
+export async function fetchTopics(params: {
+    mine?: boolean;
+    subjectId?: string;
+    termId?: string;
+}): Promise<TopicSummary[]> {
+    const res = await api.get('/catalog/topics', {
+        params: {
+            mine: params.mine ?? true,
+            subject_id: params.subjectId,
+            term_id: params.termId,
+        },
+    });
+    return res.data as TopicSummary[];
+}

--- a/frontend/src/services/grades.ts
+++ b/frontend/src/services/grades.ts
@@ -1,0 +1,88 @@
+import api from "./api";
+
+export interface AssessmentScopeTag {
+    id: string;
+    real_grade_id: string;
+    topic_id: string | null;
+    microconcept_id: string | null;
+    weight: number | null;
+}
+
+export interface RealGrade {
+    id: string;
+    student_id: string;
+    subject_id: string;
+    term_id: string;
+    assessment_date: string; // YYYY-MM-DD
+    grade_value: number;
+    grading_scale: string | null;
+    notes: string | null;
+    created_by_tutor_id: string;
+    created_at: string | null;
+    scope_tags: AssessmentScopeTag[];
+}
+
+export interface AssessmentScopeTagCreatePayload {
+    topic_id?: string | null;
+    microconcept_id?: string | null;
+    weight?: number | null;
+}
+
+export interface RealGradeCreatePayload {
+    student_id: string;
+    subject_id: string;
+    term_id: string;
+    assessment_date: string;
+    grade_value: number;
+    grading_scale?: string | null;
+    notes?: string | null;
+    scope_tags?: AssessmentScopeTagCreatePayload[];
+}
+
+export type RealGradeUpdatePayload = Partial<
+    Pick<RealGrade, "assessment_date" | "grade_value" | "grading_scale" | "notes">
+>;
+
+export async function fetchGrades(params: {
+    studentId?: string;
+    subjectId?: string;
+    termId?: string;
+    limit?: number;
+}): Promise<RealGrade[]> {
+    const res = await api.get("/grades", {
+        params: {
+            student_id: params.studentId,
+            subject_id: params.subjectId,
+            term_id: params.termId,
+            limit: params.limit ?? 50,
+        },
+    });
+    return res.data as RealGrade[];
+}
+
+export async function createGrade(payload: RealGradeCreatePayload): Promise<RealGrade> {
+    const res = await api.post("/grades", payload);
+    return res.data as RealGrade;
+}
+
+export async function updateGrade(gradeId: string, payload: RealGradeUpdatePayload): Promise<RealGrade> {
+    const res = await api.patch(`/grades/${gradeId}`, payload);
+    return res.data as RealGrade;
+}
+
+export async function deleteGrade(gradeId: string): Promise<void> {
+    await api.delete(`/grades/${gradeId}`);
+}
+
+export async function addGradeTag(
+    gradeId: string,
+    payload: AssessmentScopeTagCreatePayload
+): Promise<AssessmentScopeTag> {
+    const res = await api.post(`/grades/${gradeId}/tags`, payload);
+    return res.data as AssessmentScopeTag;
+}
+
+export async function deleteGradeTag(gradeId: string, tagId: string): Promise<void> {
+    await api.delete(`/grades/${gradeId}/tags/${tagId}`);
+}
+


### PR DESCRIPTION
﻿Implements Sprint 4 Day 2 tutor UI for real grades.

- Adds Tutor tab "Calificaciones" with create/edit/list + tag management.
- Adds frontend service for `/grades`.
- Adds `GET /catalog/topics` so tags can be selected by topic name.
- Fixes `MicroconceptManager` Set iteration so `next build` succeeds.
- Adds backend tests for catalog topics.

Fixes #57
