### PR TITLE
feat(recommendations): add outcomes evaluation

### DIFF
--- a/backend/alembic/versions/2f1c7f3b0b0a_add_recommendation_outcomes.py
+++ b/backend/alembic/versions/2f1c7f3b0b0a_add_recommendation_outcomes.py
@@ -1,0 +1,69 @@
+"""add recommendation outcomes
+
+Revision ID: 2f1c7f3b0b0a
+Revises: e8dd5bdddbb8
+Create Date: 2025-12-20 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "2f1c7f3b0b0a"
+down_revision: str | None = "e8dd5bdddbb8"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "recommendation_instances",
+        sa.Column("evaluation_window_days", sa.Integer(), server_default="14", nullable=False),
+    )
+
+    op.create_table(
+        "recommendation_outcomes",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("recommendation_id", sa.UUID(), nullable=False),
+        sa.Column("evaluation_start", sa.DateTime(), nullable=False),
+        sa.Column("evaluation_end", sa.DateTime(), nullable=False),
+        sa.Column("success", sa.String(length=20), nullable=False),
+        sa.Column("delta_mastery", sa.Numeric(10, 6), nullable=True),
+        sa.Column("delta_retention", sa.Numeric(10, 6), nullable=True),
+        sa.Column("delta_accuracy", sa.Numeric(10, 6), nullable=True),
+        sa.Column("delta_hint_rate", sa.Numeric(10, 6), nullable=True),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["recommendation_id"],
+            ["recommendation_instances.id"],
+            name="recommendation_outcomes_recommendation_id_fkey",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "recommendation_id",
+            name="recommendation_outcomes_recommendation_id_key",
+        ),
+    )
+    op.create_index(
+        "idx_recommendation_outcomes_recommendation",
+        "recommendation_outcomes",
+        ["recommendation_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_recommendation_outcomes_recommendation", table_name="recommendation_outcomes"
+    )
+    op.drop_table("recommendation_outcomes")
+    op.drop_column("recommendation_instances", "evaluation_window_days")

--- a/backend/app/schemas/recommendation.py
+++ b/backend/app/schemas/recommendation.py
@@ -58,12 +58,37 @@ class RecommendationInstanceCreate(RecommendationInstanceBase):
     evidence_list: List[RecommendationEvidenceCreate]
 
 
+class RecommendationOutcomeResponse(BaseModel):
+    id: uuid.UUID
+    recommendation_id: uuid.UUID
+    evaluation_start: datetime
+    evaluation_end: datetime
+    success: str
+    delta_mastery: float | None = None
+    delta_retention: float | None = None
+    delta_accuracy: float | None = None
+    delta_hint_rate: float | None = None
+    computed_at: datetime
+    notes: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
 class RecommendationInstanceResponse(RecommendationInstanceBase):
     id: uuid.UUID
     generated_at: datetime
     updated_at: datetime
     evidence: List[RecommendationEvidenceResponse]
     decision: Optional[TutorDecisionResponse] = None
+    outcome: Optional[RecommendationOutcomeResponse] = None
 
     class Config:
         from_attributes = True
+
+
+class RecommendationOutcomeComputeResponse(BaseModel):
+    outcomes: list[RecommendationOutcomeResponse]
+    created: int
+    updated: int
+    pending: int

--- a/backend/app/services/recommendation_outcome_service.py
+++ b/backend/app/services/recommendation_outcome_service.py
@@ -1,0 +1,283 @@
+import uuid
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.activity import LearningEvent
+from app.models.microconcept import MicroConcept
+from app.models.recommendation import (
+    RecommendationInstance,
+    RecommendationOutcome,
+    RecommendationStatus,
+)
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _compute_window_metrics(
+    db: Session,
+    *,
+    student_id: uuid.UUID,
+    subject_id: uuid.UUID,
+    term_id: uuid.UUID,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, float]:
+    events = (
+        db.query(LearningEvent)
+        .filter(
+            LearningEvent.student_id == student_id,
+            LearningEvent.subject_id == subject_id,
+            LearningEvent.term_id == term_id,
+            LearningEvent.timestamp_start >= window_start,
+            LearningEvent.timestamp_start < window_end,
+        )
+        .all()
+    )
+
+    if not events:
+        return {"accuracy": 0.0, "hint_rate": 0.0}
+
+    total = len(events)
+    correct = sum(1 for e in events if e.is_correct)
+    hint = sum(1 for e in events if e.hint_used and e.hint_used != "none")
+
+    return {
+        "accuracy": correct / total if total else 0.0,
+        "hint_rate": hint / total if total else 0.0,
+    }
+
+
+def _compute_microconcept_mastery_at(
+    db: Session,
+    *,
+    student_id: uuid.UUID,
+    microconcept_id: uuid.UUID,
+    now: datetime,
+) -> float:
+    events = (
+        db.query(LearningEvent)
+        .filter(
+            LearningEvent.student_id == student_id,
+            LearningEvent.microconcept_id == microconcept_id,
+            LearningEvent.timestamp_start <= now,
+        )
+        .order_by(LearningEvent.timestamp_start.desc())
+        .all()
+    )
+    if not events:
+        return 0.0
+
+    total = len(events)
+    correct = sum(1 for e in events if e.is_correct)
+    hint = sum(1 for e in events if e.hint_used and e.hint_used != "none")
+
+    accuracy = correct / total if total else 0.0
+    hint_rate = hint / total if total else 0.0
+
+    last_practice = events[0].timestamp_start
+    days_since_practice = (now - last_practice).days
+    recency_factor = max(0.5, 1.0 - (days_since_practice / 30.0))
+
+    mastery_score = accuracy * (1.0 - hint_rate) * recency_factor
+    return round(mastery_score, 6)
+
+
+def _compute_subject_mastery_at(
+    db: Session,
+    *,
+    student_id: uuid.UUID,
+    subject_id: uuid.UUID,
+    term_id: uuid.UUID,
+    now: datetime,
+) -> float:
+    microconcept_ids = [
+        mc.id
+        for mc in db.query(MicroConcept)
+        .filter(
+            MicroConcept.subject_id == subject_id,
+            MicroConcept.term_id == term_id,
+            MicroConcept.active == True,  # noqa: E712
+        )
+        .all()
+    ]
+    if not microconcept_ids:
+        return 0.0
+
+    scores = [
+        _compute_microconcept_mastery_at(
+            db,
+            student_id=student_id,
+            microconcept_id=microconcept_id,
+            now=now,
+        )
+        for microconcept_id in microconcept_ids
+    ]
+    return round(sum(scores) / len(scores), 6)
+
+
+def _classify_success(delta_mastery: float | None, delta_accuracy: float | None) -> str:
+    mastery = delta_mastery if delta_mastery is not None else 0.0
+    accuracy = delta_accuracy if delta_accuracy is not None else 0.0
+
+    if mastery >= 0.05 or accuracy >= 0.05:
+        return "true"
+    if mastery <= -0.05 and accuracy <= -0.05:
+        return "false"
+    return "partial"
+
+
+class RecommendationOutcomeService:
+    def compute_outcomes(
+        self,
+        db: Session,
+        *,
+        tutor_id: uuid.UUID,
+        student_id: uuid.UUID,
+        subject_id: uuid.UUID,
+        term_id: uuid.UUID,
+        force: bool = False,
+        now: datetime | None = None,
+    ) -> tuple[list[RecommendationOutcome], int, int, int]:
+        """
+        Computes outcomes for accepted recommendations belonging to a tutor.
+
+        Returns: (upserted_outcomes, created_count, updated_count, pending_count)
+        """
+        now = now or datetime.utcnow()
+
+        recommendations = (
+            db.query(RecommendationInstance)
+            .options(
+                selectinload(RecommendationInstance.decision),
+                selectinload(RecommendationInstance.outcome),
+            )
+            .filter(
+                RecommendationInstance.student_id == student_id,
+                RecommendationInstance.status == RecommendationStatus.ACCEPTED,
+            )
+            .all()
+        )
+
+        upserted: list[RecommendationOutcome] = []
+        created = 0
+        updated = 0
+        pending = 0
+
+        for rec in recommendations:
+            decision = rec.decision
+            if not decision or decision.decision != "accepted" or decision.tutor_id != tutor_id:
+                continue
+
+            evaluation_start = decision.decision_at
+            window_days = rec.evaluation_window_days or 14
+            evaluation_end = evaluation_start + timedelta(days=window_days)
+
+            if evaluation_end > now:
+                pending += 1
+                continue
+
+            if rec.outcome and not force:
+                continue
+
+            pre_start = evaluation_start - timedelta(days=window_days)
+            pre = _compute_window_metrics(
+                db,
+                student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
+                window_start=pre_start,
+                window_end=evaluation_start,
+            )
+            post = _compute_window_metrics(
+                db,
+                student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
+                window_start=evaluation_start,
+                window_end=evaluation_end,
+            )
+
+            delta_accuracy = post["accuracy"] - pre["accuracy"]
+            delta_hint_rate = post["hint_rate"] - pre["hint_rate"]
+
+            if rec.microconcept_id:
+                mastery_start = _compute_microconcept_mastery_at(
+                    db,
+                    student_id=student_id,
+                    microconcept_id=rec.microconcept_id,
+                    now=evaluation_start,
+                )
+                mastery_end = _compute_microconcept_mastery_at(
+                    db,
+                    student_id=student_id,
+                    microconcept_id=rec.microconcept_id,
+                    now=evaluation_end,
+                )
+            else:
+                mastery_start = _compute_subject_mastery_at(
+                    db,
+                    student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
+                    now=evaluation_start,
+                )
+                mastery_end = _compute_subject_mastery_at(
+                    db,
+                    student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
+                    now=evaluation_end,
+                )
+
+            delta_mastery = mastery_end - mastery_start
+            success = _classify_success(delta_mastery, delta_accuracy)
+
+            if rec.outcome:
+                outcome = rec.outcome
+                outcome.evaluation_start = evaluation_start
+                outcome.evaluation_end = evaluation_end
+                outcome.success = success
+                outcome.delta_mastery = delta_mastery
+                outcome.delta_accuracy = delta_accuracy
+                outcome.delta_hint_rate = delta_hint_rate
+                outcome.computed_at = now
+                db.add(outcome)
+                updated += 1
+            else:
+                outcome = RecommendationOutcome(
+                    id=uuid.uuid4(),
+                    recommendation_id=rec.id,
+                    evaluation_start=evaluation_start,
+                    evaluation_end=evaluation_end,
+                    success=success,
+                    delta_mastery=delta_mastery,
+                    delta_accuracy=delta_accuracy,
+                    delta_hint_rate=delta_hint_rate,
+                    computed_at=now,
+                    notes=None,
+                )
+                db.add(outcome)
+                created += 1
+
+            upserted.append(outcome)
+
+        db.commit()
+        for outcome in upserted:
+            db.refresh(outcome)
+
+        return upserted, created, updated, pending
+
+
+recommendation_outcome_service = RecommendationOutcomeService()

--- a/backend/tests/test_recommendation_outcomes.py
+++ b/backend/tests/test_recommendation_outcomes.py
@@ -1,0 +1,256 @@
+import uuid
+from datetime import date, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.db import SessionLocal
+from app.core.security import get_password_hash
+from app.main import app
+from app.models.activity import ActivitySession, ActivityType, LearningEvent
+from app.models.content import ContentUpload, ContentUploadType
+from app.models.item import Item, ItemType
+from app.models.microconcept import MicroConcept
+from app.models.recommendation import (
+    RecommendationInstance,
+    RecommendationPriority,
+    RecommendationStatus,
+    TutorDecision,
+)
+from app.models.role import Role
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import AcademicYear, Term
+from app.models.tutor import Tutor
+from app.models.user import User
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def db_session() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _ensure_role(db: Session, name: str) -> Role:
+    role = db.query(Role).filter_by(name=name).first()
+    if not role:
+        role = Role(name=name)
+        db.add(role)
+        db.commit()
+    return role
+
+
+def _login(email: str, password: str) -> dict[str, str]:
+    res = client.post("/api/v1/login/access-token", json={"email": email, "password": password})
+    assert res.status_code == 200
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_compute_recommendation_outcomes_creates_outcome(db_session: Session):
+    uid = uuid.uuid4()
+    role_tutor = _ensure_role(db_session, "Tutor")
+    role_student = _ensure_role(db_session, "Student")
+
+    password = "pw"
+    tutor_user = User(
+        id=uuid.uuid4(),
+        email=f"t_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    student_user = User(
+        id=uuid.uuid4(),
+        email=f"s_{uid}@example.com",
+        hashed_password="x",
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add_all([tutor_user, student_user])
+    db_session.flush()
+
+    tutor = Tutor(user_id=tutor_user.id, display_name="Tutor Outcomes")
+    subject = Subject(name=f"Subject {uid}", tutor_id=tutor_user.id)
+    db_session.add_all([tutor, subject])
+    db_session.flush()
+
+    student = Student(user_id=student_user.id, subject_id=subject.id)
+    db_session.add(student)
+    db_session.flush()
+
+    year = AcademicYear(
+        name=f"2025-2026-{uid}",
+        start_date=date(2025, 9, 1),
+        end_date=date(2026, 6, 30),
+    )
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    db_session.add_all([year, term])
+    db_session.flush()
+
+    microconcept = MicroConcept(
+        subject_id=subject.id, term_id=term.id, name="MC A", description="..."
+    )
+    db_session.add(microconcept)
+    db_session.flush()
+
+    upload = ContentUpload(
+        tutor_id=tutor.id,
+        student_id=student.id,
+        subject_id=subject.id,
+        term_id=term.id,
+        topic_id=None,
+        upload_type=ContentUploadType.pdf,
+        storage_uri="file://test.pdf",
+        file_name="test.pdf",
+        mime_type="application/pdf",
+        page_count=1,
+    )
+    db_session.add(upload)
+    db_session.flush()
+
+    item = Item(
+        content_upload_id=upload.id,
+        microconcept_id=microconcept.id,
+        type=ItemType.MCQ,
+        stem="2+2?",
+        options={"choices": ["3", "4"]},
+        correct_answer="4",
+        explanation="2+2=4",
+        difficulty=1,
+        is_active=True,
+    )
+    db_session.add(item)
+    db_session.flush()
+
+    quiz_type = db_session.query(ActivityType).filter_by(code="QUIZ").first()
+    if not quiz_type:
+        quiz_type = ActivityType(code="QUIZ", name="Quiz", active=True)
+        db_session.add(quiz_type)
+        db_session.flush()
+
+    now = datetime.utcnow()
+    decision_at = now - timedelta(days=20)
+    window_days = 14
+
+    session = ActivitySession(
+        student_id=student.id,
+        activity_type_id=quiz_type.id,
+        subject_id=subject.id,
+        term_id=term.id,
+        topic_id=None,
+        started_at=decision_at - timedelta(days=1),
+        ended_at=decision_at - timedelta(days=1) + timedelta(minutes=5),
+        status="completed",
+        device_type="web",
+    )
+    db_session.add(session)
+    db_session.flush()
+
+    # Pre-window: mostly incorrect
+    pre_start = decision_at - timedelta(days=window_days)
+    for i in range(5):
+        ts = pre_start + timedelta(days=i + 1)
+        db_session.add(
+            LearningEvent(
+                student_id=student.id,
+                session_id=session.id,
+                subject_id=subject.id,
+                term_id=term.id,
+                topic_id=None,
+                microconcept_id=microconcept.id,
+                activity_type_id=quiz_type.id,
+                item_id=item.id,
+                timestamp_start=ts,
+                timestamp_end=ts + timedelta(seconds=10),
+                duration_ms=10_000,
+                attempt_number=1,
+                response_normalized="3",
+                is_correct=False,
+                hint_used="none",
+                difficulty_at_time=1,
+            )
+        )
+
+    # Post-window: mostly correct
+    post_end = decision_at + timedelta(days=window_days)
+    for i in range(5):
+        ts = decision_at + timedelta(days=i + 1)
+        if ts >= post_end:
+            ts = post_end - timedelta(hours=1)
+        db_session.add(
+            LearningEvent(
+                student_id=student.id,
+                session_id=session.id,
+                subject_id=subject.id,
+                term_id=term.id,
+                topic_id=None,
+                microconcept_id=microconcept.id,
+                activity_type_id=quiz_type.id,
+                item_id=item.id,
+                timestamp_start=ts,
+                timestamp_end=ts + timedelta(seconds=10),
+                duration_ms=10_000,
+                attempt_number=1,
+                response_normalized="4",
+                is_correct=True,
+                hint_used="none",
+                difficulty_at_time=1,
+            )
+        )
+
+    recommendation = RecommendationInstance(
+        id=uuid.uuid4(),
+        student_id=student.id,
+        microconcept_id=microconcept.id,
+        rule_id="R11",
+        priority=RecommendationPriority.MEDIUM,
+        status=RecommendationStatus.ACCEPTED,
+        title="Refuerzo MC A",
+        description="...",
+        evaluation_window_days=window_days,
+        generated_at=decision_at - timedelta(days=1),
+        updated_at=decision_at,
+    )
+    db_session.add(recommendation)
+    db_session.flush()
+
+    decision = TutorDecision(
+        id=uuid.uuid4(),
+        recommendation_id=recommendation.id,
+        tutor_id=tutor.id,
+        decision="accepted",
+        notes=None,
+        decision_at=decision_at,
+    )
+    db_session.add(decision)
+    db_session.commit()
+
+    headers = _login(tutor_user.email, password)
+
+    res = client.post(
+        "/api/v1/recommendations/outcomes/compute",
+        params={
+            "student_id": str(student.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+        },
+        headers=headers,
+    )
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["created"] == 1
+    assert payload["updated"] == 0
+    assert payload["pending"] == 0
+    assert len(payload["outcomes"]) == 1
+    outcome = payload["outcomes"][0]
+    assert outcome["recommendation_id"] == str(recommendation.id)
+    assert outcome["success"] in {"true", "partial", "false"}
+    assert outcome["delta_accuracy"] is not None
+    assert outcome["delta_accuracy"] > 0


### PR DESCRIPTION
﻿Implements Sprint 4 Day 4 outcomes evaluation (feedback loop).

- Adds `recommendation_outcomes` table + `evaluation_window_days` on recommendations.
- Adds service to compute deltas (accuracy/hint_rate/mastery) and classify success.
- Adds tutor endpoint `POST /recommendations/outcomes/compute`.
- Adds tests for outcome computation.

Fixes #59
