### PR TITLE
feat(metrics): add review scheduling

### DIFF
--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -172,6 +172,7 @@ def get_student_mastery(
                 mastery_score=ms.mastery_score,
                 status=ms.status,
                 last_practice_at=ms.last_practice_at,
+                recommended_next_review_at=ms.recommended_next_review_at,
                 total_events=event_count,
             )
         )

--- a/backend/app/schemas/metric.py
+++ b/backend/app/schemas/metric.py
@@ -80,4 +80,5 @@ class MasteryStateSummary(BaseModel):
     mastery_score: float
     status: str
     last_practice_at: datetime | None
+    recommended_next_review_at: datetime | None = None
     total_events: int

--- a/backend/tests/test_mastery.py
+++ b/backend/tests/test_mastery.py
@@ -41,6 +41,7 @@ def test_mastery_score_calculation(db_session, metric_service):
     for state in mastery_states:
         # Mastery score should be between 0 and 1
         assert 0.0 <= state.mastery_score <= 1.0
+        assert state.recommended_next_review_at is not None
 
         # Status should match score thresholds
         if state.mastery_score >= 0.8:


### PR DESCRIPTION
Fixes #72\n\n- Calcula ecommended_next_review_at en calculate_mastery_states/recalc.\n- Expone ecommended_next_review_at en GET /metrics/.../mastery.\n- Añade test básico para el schedule.