### PR TITLE
feat(recommendations): catalog guardrails + tutor metadata

### DIFF
--- a/backend/alembic/versions/b3cfe90abd0c_add_recommendation_catalog.py
+++ b/backend/alembic/versions/b3cfe90abd0c_add_recommendation_catalog.py
@@ -1,0 +1,307 @@
+"""add recommendation catalog
+
+Revision ID: b3cfe90abd0c
+Revises: 2f1c7f3b0b0a
+Create Date: 2025-12-20 23:27:36.291628
+
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3cfe90abd0c"
+down_revision: str | None = "2f1c7f3b0b0a"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    recommendation_catalog = op.create_table(
+        "recommendation_catalog",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("code", sa.String(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("category", sa.String(), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("catalog_version", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("code"),
+    )
+
+    rows: list[dict[str, object]] = []
+    base = {
+        "active": True,
+        "catalog_version": "V1",
+    }
+
+    def add(code: str, title: str, description: str, category: str) -> None:
+        rows.append(
+            {
+                **base,
+                "id": uuid.uuid4(),
+                "code": code,
+                "title": title,
+                "description": description,
+                "category": category,
+            }
+        )
+
+    # Focus (R01-R10)
+    add(
+        "R01",
+        "Priorizar microconceptos en riesgo",
+        "Enfocar práctica en microconceptos con dominio bajo y errores recurrentes.",
+        "focus",
+    )
+    add(
+        "R02",
+        "Consolidar microconceptos en progreso",
+        "Aumentar práctica para microconceptos con dominio medio e inconsistencia.",
+        "focus",
+    )
+    add(
+        "R03",
+        "Repaso espaciado de microconceptos dominados",
+        "Programar repasos para mantener retención en conceptos ya dominados.",
+        "focus",
+    )
+    add(
+        "R04",
+        "Reducir carga de nuevos conceptos",
+        "Disminuir introducción de nuevo contenido si hay demasiados conceptos en riesgo.",
+        "focus",
+    )
+    add(
+        "R05",
+        "Reforzar prerequisitos",
+        "Volver a prerequisitos cuando se detecten fallos base repetidos.",
+        "focus",
+    )
+    add(
+        "R06",
+        "Reorganizar orden del trimestre",
+        "Reordenar el plan cuando la secuencia actual no es óptima para el alumno.",
+        "focus",
+    )
+    add(
+        "R07",
+        "Aumentar repetición inmediata tras errores",
+        "Aplicar repetición inmediata para corregir errores persistentes.",
+        "focus",
+    )
+    add(
+        "R08",
+        "Introducir microevaluaciones frecuentes",
+        "Usar comprobaciones cortas y frecuentes para detectar fallos pronto.",
+        "focus",
+    )
+    add(
+        "R09",
+        "Separar conceptos confundidos",
+        "Desambiguar conceptos similares mediante práctica diferenciada.",
+        "focus",
+    )
+    add(
+        "R10",
+        "Simplificar dificultad temporalmente",
+        "Bajar dificultad para recuperar confianza y evitar bloqueo.",
+        "focus",
+    )
+
+    # Strategy (R11-R20)
+    add(
+        "R11",
+        "Aumentar recuperación sin ayudas",
+        "Reducir dependencia de ayudas incrementando práctica de recuperación.",
+        "strategy",
+    )
+    add(
+        "R12",
+        "Limitar uso de pistas",
+        "Limitar pistas si se detecta dependencia excesiva.",
+        "strategy",
+    )
+    add(
+        "R13",
+        "Sustituir repaso pasivo por práctica activa",
+        "Reemplazar lectura/teoría por ejercicios de recuperación.",
+        "strategy",
+    )
+    add(
+        "R14",
+        "Introducir intercalado",
+        "Mezclar temas para mejorar discriminación y transferencia.",
+        "strategy",
+    )
+    add(
+        "R15",
+        "Volver a práctica bloqueada",
+        "Volver a práctica por bloques si el intercalado empeora el rendimiento.",
+        "strategy",
+    )
+    add(
+        "R16",
+        "Cambiar tipo de actividad",
+        "Cambiar formato de juego hacia el más eficaz para el alumno.",
+        "strategy",
+    )
+    add(
+        "R17",
+        "Aumentar ejemplos concretos",
+        "Añadir ejemplos guiados si hay errores conceptuales persistentes.",
+        "strategy",
+    )
+    add(
+        "R18",
+        "Introducir variabilidad controlada",
+        "Añadir variabilidad cuando hay dominio aparente pero baja transferencia.",
+        "strategy",
+    )
+    add(
+        "R19",
+        "Añadir explicación tras error",
+        "Mostrar explicación breve tras error cuando el mismo error se repite.",
+        "strategy",
+    )
+    add(
+        "R20",
+        "Reducir explicación anticipada",
+        "Evitar explicación previa excesiva cuando el alumno aprende bien por ensayo.",
+        "strategy",
+    )
+
+    # Dosage (R21-R30)
+    add(
+        "R21",
+        "Reducir duración de sesiones",
+        "Acortar sesiones si hay fatiga intras sesión detectada.",
+        "dosage",
+    )
+    add(
+        "R22",
+        "Aumentar sesiones cortas",
+        "Aumentar frecuencia de sesiones breves si mejoran el rendimiento.",
+        "dosage",
+    )
+    add(
+        "R23",
+        "Introducir descansos",
+        "Insertar descansos si aumenta el abandono o baja la atención.",
+        "dosage",
+    )
+    add(
+        "R24",
+        "Ajustar ritmo",
+        "Ajustar ritmo de presentación según balance tiempo/accuracy.",
+        "dosage",
+    )
+    add(
+        "R25",
+        "Añadir pausa reflexiva",
+        "Añadir pausas si responde demasiado rápido con muchos errores.",
+        "dosage",
+    )
+    add(
+        "R26",
+        "Aumentar automatización",
+        "Aumentar práctica para reducir tiempo de respuesta manteniendo accuracy.",
+        "dosage",
+    )
+    add(
+        "R27",
+        "Reducir volumen diario",
+        "Reducir carga diaria si hay retroceso por exceso de volumen.",
+        "dosage",
+    )
+    add(
+        "R28",
+        "Incrementar volumen",
+        "Aumentar carga si hay dominio estable y margen de progreso.",
+        "dosage",
+    )
+    add(
+        "R29",
+        "Ajustar dificultad",
+        "Subir dificultad cuando el alumno se mantiene estable en alto rendimiento.",
+        "dosage",
+    )
+    add(
+        "R30",
+        "Alternar días intensivos y ligeros",
+        "Alternar intensidad para estabilizar rendimiento semanal.",
+        "dosage",
+    )
+
+    # External validation (R31-R40)
+    add(
+        "R31",
+        "Ejercicios tipo examen",
+        "Introducir ejercicios tipo examen si hay discrepancia con nota real.",
+        "external_validation",
+    )
+    add(
+        "R32",
+        "Revisar alineación temario",
+        "Revisar si los ítems cubren el temario real evaluado.",
+        "external_validation",
+    )
+    add(
+        "R33",
+        "Etiquetado por tutor",
+        "Solicitar más contexto/etiquetado cuando la evaluación real es ambigua.",
+        "external_validation",
+    )
+    add(
+        "R34",
+        "Reforzar transferencia",
+        "Reforzar transferencia cuando falla en ítems nuevos pese a buen desempeño.",
+        "external_validation",
+    )
+    add(
+        "R35",
+        "Priorizar conceptos clave del examen",
+        "Priorizar conceptos marcados como clave por su peso evaluativo.",
+        "external_validation",
+    )
+    add(
+        "R36",
+        "Reducir confianza excesiva",
+        "Detectar falso dominio y ajustar cuando el examen contradice el desempeño.",
+        "external_validation",
+    )
+    add(
+        "R37",
+        "Revisar consistencia entre sesiones",
+        "Revisar variabilidad alta entre sesiones para evitar diagnósticos erróneos.",
+        "external_validation",
+    )
+    add(
+        "R38",
+        "Activar revisión tutor–alumno",
+        "Proponer revisión conjunta cuando hay señales contradictorias.",
+        "external_validation",
+    )
+    add(
+        "R39",
+        "Mantener estrategia actual",
+        "Mantener estrategia si hay mejora sostenida y consistente.",
+        "external_validation",
+    )
+    add(
+        "R40",
+        "Reevaluar tras no mejora",
+        "Reevaluar estrategia si no hay mejora tras ventana de evaluación.",
+        "external_validation",
+    )
+
+    op.bulk_insert(recommendation_catalog, rows)
+
+
+def downgrade() -> None:
+    op.drop_table("recommendation_catalog")

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -36,6 +36,7 @@ from app.models import (  # noqa: E402, F401, I001
     microconcept,
     report,
     role,
+    recommendation_catalog,
     student,
     subject,
     term,

--- a/backend/app/models/recommendation_catalog.py
+++ b/backend/app/models/recommendation_catalog.py
@@ -1,0 +1,19 @@
+import uuid
+
+from sqlalchemy import Boolean, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.db import Base
+
+
+class RecommendationCatalog(Base):
+    __tablename__ = "recommendation_catalog"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    code: Mapped[str] = mapped_column(String, nullable=False, unique=True)  # R01..R40
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str] = mapped_column(String, nullable=False)
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    catalog_version: Mapped[str] = mapped_column(String, nullable=False, default="V1")

--- a/backend/app/schemas/recommendation.py
+++ b/backend/app/schemas/recommendation.py
@@ -48,6 +48,7 @@ class RecommendationInstanceBase(BaseModel):
     student_id: uuid.UUID
     microconcept_id: Optional[uuid.UUID] = None
     rule_id: str
+    category: Optional[str] = None
     priority: str
     status: str
     title: str

--- a/frontend/src/components/tutor/RecommendationCard.tsx
+++ b/frontend/src/components/tutor/RecommendationCard.tsx
@@ -16,6 +16,7 @@ interface Recommendation {
     priority: 'high' | 'medium' | 'low';
     status: 'pending' | 'accepted' | 'rejected';
     rule_id: string;
+    category?: string | null;
     generated_at: string;
     evidence: Evidence[];
     outcome?: {
@@ -40,6 +41,16 @@ interface RecommendationCardProps {
 
 export default function RecommendationCard({ recommendation, tutorId, onDecisionMade }: RecommendationCardProps) {
     const [loading, setLoading] = useState(false);
+
+    const categoryLabel = (category: string | null | undefined) => {
+        switch ((category || '').toLowerCase()) {
+            case 'focus': return 'Focus';
+            case 'strategy': return 'Estrategia';
+            case 'dosage': return 'Dosificación';
+            case 'external_validation': return 'Validación externa';
+            default: return null;
+        }
+    };
 
     const handleDecision = async (decision: 'accepted' | 'rejected') => {
         setLoading(true);
@@ -89,9 +100,19 @@ export default function RecommendationCard({ recommendation, tutorId, onDecision
         <div className="card" style={{ borderLeft: `4px solid ${getPriorityColor(recommendation.priority)}` }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                 <div>
-                    <span className="badge" style={{ backgroundColor: getPriorityColor(recommendation.priority), marginBottom: '0.5rem' }}>
-                        {recommendation.priority.toUpperCase()}
-                    </span>
+                    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.5rem' }}>
+                        <span className="badge" style={{ backgroundColor: getPriorityColor(recommendation.priority) }}>
+                            {recommendation.priority.toUpperCase()}
+                        </span>
+                        <span className="badge" style={{ backgroundColor: 'var(--bg-secondary)', color: 'var(--text-primary)', border: '1px solid var(--border-color)' }}>
+                            {recommendation.rule_id}
+                        </span>
+                        {categoryLabel(recommendation.category) && (
+                            <span className="badge" style={{ backgroundColor: 'var(--bg-secondary)', color: 'var(--text-secondary)', border: '1px solid var(--border-color)' }}>
+                                {categoryLabel(recommendation.category)}
+                            </span>
+                        )}
+                    </div>
                     <h3 style={{ margin: '0.5rem 0' }}>{recommendation.title}</h3>
                 </div>
                 <div style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>

--- a/frontend/src/components/tutor/RecommendationList.tsx
+++ b/frontend/src/components/tutor/RecommendationList.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import api from '../../services/api';
 import RecommendationCard from './RecommendationCard';
 
+type SortKey = 'newest' | 'priority' | 'category';
+
 interface RecommendationListProps {
     studentId: string;
     subjectId: string;
@@ -13,6 +15,8 @@ export default function RecommendationList({ studentId, subjectId, termId, tutor
     const [recommendations, setRecommendations] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [filter, setFilter] = useState('pending'); // pending, all, accepted, rejected
+    const [categoryFilter, setCategoryFilter] = useState<string>('all');
+    const [sortKey, setSortKey] = useState<SortKey>('priority');
     const [computingOutcomes, setComputingOutcomes] = useState(false);
     const [outcomeMessage, setOutcomeMessage] = useState<string | null>(null);
 
@@ -38,6 +42,45 @@ export default function RecommendationList({ studentId, subjectId, termId, tutor
     useEffect(() => {
         fetchRecommendations();
     }, [fetchRecommendations]);
+
+    const getPriorityRank = (priority: string) => {
+        switch ((priority || '').toLowerCase()) {
+            case 'high': return 0;
+            case 'medium': return 1;
+            case 'low': return 2;
+            default: return 3;
+        }
+    };
+
+    const getCategoryRank = (category: string) => {
+        switch ((category || '').toLowerCase()) {
+            case 'focus': return 0;
+            case 'strategy': return 1;
+            case 'dosage': return 2;
+            case 'external_validation': return 3;
+            default: return 4;
+        }
+    };
+
+    const visibleRecommendations = recommendations
+        .filter(rec => categoryFilter === 'all' || (rec.category || '').toLowerCase() === categoryFilter)
+        .slice()
+        .sort((a, b) => {
+            if (sortKey === 'newest') {
+                return new Date(b.generated_at).getTime() - new Date(a.generated_at).getTime();
+            }
+            if (sortKey === 'category') {
+                const c = getCategoryRank(a.category) - getCategoryRank(b.category);
+                if (c !== 0) return c;
+                const p = getPriorityRank(a.priority) - getPriorityRank(b.priority);
+                if (p !== 0) return p;
+                return new Date(b.generated_at).getTime() - new Date(a.generated_at).getTime();
+            }
+
+            const p = getPriorityRank(a.priority) - getPriorityRank(b.priority);
+            if (p !== 0) return p;
+            return new Date(b.generated_at).getTime() - new Date(a.generated_at).getTime();
+        });
 
     const computeOutcomes = async (force = false) => {
         setComputingOutcomes(true);
@@ -85,7 +128,7 @@ export default function RecommendationList({ studentId, subjectId, termId, tutor
         <div style={{ padding: '1rem' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
                 <h2>Recomendaciones de Estudio</h2>
-                <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+                <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
                     <button
                         className="btn btn-secondary"
                         onClick={() => computeOutcomes(false)}
@@ -102,6 +145,30 @@ export default function RecommendationList({ studentId, subjectId, termId, tutor
                     >
                         Forzar
                     </button>
+                    <select
+                        value={categoryFilter}
+                        onChange={(e) => setCategoryFilter(e.target.value)}
+                        className="input"
+                        style={{ width: 'auto' }}
+                        title="Filtrar por categoría"
+                    >
+                        <option value="all">Todas las categorías</option>
+                        <option value="focus">Focus</option>
+                        <option value="strategy">Estrategia</option>
+                        <option value="dosage">Dosificación</option>
+                        <option value="external_validation">Validación externa</option>
+                    </select>
+                    <select
+                        value={sortKey}
+                        onChange={(e) => setSortKey(e.target.value as SortKey)}
+                        className="input"
+                        style={{ width: 'auto' }}
+                        title="Ordenar recomendaciones"
+                    >
+                        <option value="priority">Ordenar por prioridad</option>
+                        <option value="category">Ordenar por categoría</option>
+                        <option value="newest">Más recientes</option>
+                    </select>
                     <select
                         value={filter}
                         onChange={(e) => setFilter(e.target.value)}
@@ -129,9 +196,14 @@ export default function RecommendationList({ studentId, subjectId, termId, tutor
                     <p>No hay recomendaciones {filter === 'pending' ? 'pendientes' : 'disponibles'} en este momento.</p>
                     <p style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>El sistema genera sugerencias basadas en la actividad reciente del alumno.</p>
                 </div>
+            ) : visibleRecommendations.length === 0 ? (
+                <div style={{ padding: '2rem', textAlign: 'center', backgroundColor: 'var(--bg-secondary)', borderRadius: 'var(--radius-md)' }}>
+                    <p>No hay recomendaciones que coincidan con los filtros actuales.</p>
+                    <p style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>Prueba a cambiar la categoría o el estado.</p>
+                </div>
             ) : (
                 <div style={{ display: 'grid', gap: '1.5rem', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))' }}>
-                    {recommendations.map(rec => (
+                    {visibleRecommendations.map(rec => (
                         <RecommendationCard
                             key={rec.id}
                             recommendation={rec}


### PR DESCRIPTION
Adds ecommendation_catalog (seeded R01–R40), enforces a catalog guardrail for RecommendationInstance creation, and exposes category metadata in Tutor recommendations UI (filter/sort + badges).

Fixes #90