### PR TITLE
fix(recommendations): stabilize tutor report metadata

### DIFF
--- a/backend/tests/e2e/test_e2e_04_outcomes_report.py
+++ b/backend/tests/e2e/test_e2e_04_outcomes_report.py
@@ -226,6 +226,8 @@ def test_e2e_04_grade_report_recommendation_outcome_flow(db_session: Session):
     pending_recs = recs_res.json()
     assert pending_recs
     target_rec = next((r for r in pending_recs if r["rule_id"] == "R01"), pending_recs[0])
+    allowed_categories = {"focus", "strategy", "dosage", "external_validation"}
+    assert all(r.get("category") in allowed_categories for r in pending_recs)
 
     decision_res = client.post(
         f"/api/v1/recommendations/{target_rec['id']}/decision",
@@ -377,3 +379,6 @@ def test_e2e_04_grade_report_recommendation_outcome_flow(db_session: Session):
     section = next(s for s in report2["sections"] if s["section_type"] == "recommendation_outcomes")
     assert section["data"]["stats"]["with_outcome"] >= 1
     assert any(e.get("outcome") for e in section["data"]["accepted"])
+    first = next(e for e in section["data"]["accepted"] if e.get("outcome"))
+    assert first.get("rule_id")
+    assert first.get("category") in {"focus", "strategy", "dosage", "external_validation"}

--- a/frontend/src/components/tutor/TutorReportPanel.tsx
+++ b/frontend/src/components/tutor/TutorReportPanel.tsx
@@ -78,6 +78,16 @@ export default function TutorReportPanel({ tutorId, studentId, subjectId, termId
         return `${sign}${value.toFixed(3)}`;
     }, []);
 
+    const categoryLabel = useCallback((category: string | null | undefined) => {
+        switch ((category || '').toLowerCase()) {
+            case 'focus': return 'Focus';
+            case 'strategy': return 'Estrategia';
+            case 'dosage': return 'Dosificación';
+            case 'external_validation': return 'Validación externa';
+            default: return null;
+        }
+    }, []);
+
     const outcomeBadge = useCallback((success: string | null | undefined) => {
         const normalized = (success || '').toLowerCase();
         if (!normalized) return { label: 'Pendiente', color: 'var(--text-secondary)' };
@@ -195,6 +205,8 @@ export default function TutorReportPanel({ tutorId, studentId, subjectId, termId
                                                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                                                     <thead>
                                                         <tr style={{ textAlign: 'left', color: 'var(--text-secondary)' }}>
+                                                            <th style={{ padding: '0.5rem' }}>Código</th>
+                                                            <th style={{ padding: '0.5rem' }}>Categoría</th>
                                                             <th style={{ padding: '0.5rem' }}>Recomendación</th>
                                                             <th style={{ padding: '0.5rem' }}>Impacto</th>
                                                             <th style={{ padding: '0.5rem' }}>Δ Accuracy</th>
@@ -206,8 +218,17 @@ export default function TutorReportPanel({ tutorId, studentId, subjectId, termId
                                                     <tbody>
                                                         {section.data.accepted.map((entry: any) => {
                                                             const badge = outcomeBadge(entry?.outcome?.success);
+                                                            const category = categoryLabel(entry?.category);
                                                             return (
                                                                 <tr key={entry.id} style={{ borderTop: '1px solid var(--border-color)' }}>
+                                                                    <td style={{ padding: '0.5rem' }}>
+                                                                        <span className="badge" style={{ backgroundColor: 'var(--bg-secondary)', color: 'var(--text-primary)', border: '1px solid var(--border-color)' }}>
+                                                                            {entry?.rule_id || '-'}
+                                                                        </span>
+                                                                    </td>
+                                                                    <td style={{ padding: '0.5rem', color: 'var(--text-secondary)' }}>
+                                                                        {category || '-'}
+                                                                    </td>
                                                                     <td style={{ padding: '0.5rem' }}>{entry.title}</td>
                                                                     <td style={{ padding: '0.5rem' }}>
                                                                         <span className="badge" style={{ backgroundColor: badge.color }}>


### PR DESCRIPTION
Adds recommendation metadata (rule_id/category/priority) into tutor reports payload and shows it in Tutor report outcomes table; updates E2E to assert categories are present.

Fixes #91