### PR TITLE
test(docs): add E2E-06 external validation runbook

### DIFF
--- a/backend/tests/e2e/test_e2e_06_external_validation_report.py
+++ b/backend/tests/e2e/test_e2e_06_external_validation_report.py
@@ -1,0 +1,211 @@
+import uuid
+from datetime import date, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.db import SessionLocal
+from app.core.security import get_password_hash
+from app.main import app
+from app.models.activity import ActivityType
+from app.models.metric import MasteryState, MetricAggregate
+from app.models.microconcept import MicroConcept
+from app.models.role import Role
+from app.models.student import Student
+from app.models.subject import Subject
+from app.models.term import AcademicYear, Term
+from app.models.tutor import Tutor
+from app.models.user import User
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def db_session() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _ensure_role(db: Session, name: str) -> Role:
+    role = db.query(Role).filter_by(name=name).first()
+    if role:
+        return role
+    role = Role(name=name)
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    return role
+
+
+def _ensure_activity_type(db: Session, code: str) -> ActivityType:
+    activity_type = db.query(ActivityType).filter_by(code=code).first()
+    if activity_type:
+        return activity_type
+    activity_type = ActivityType(id=uuid.uuid4(), code=code, name=code, active=True)
+    db.add(activity_type)
+    db.commit()
+    db.refresh(activity_type)
+    return activity_type
+
+
+def _login(email: str, password: str) -> dict[str, str]:
+    res = client.post("/api/v1/login/access-token", json={"email": email, "password": password})
+    assert res.status_code == 200
+    return {"Authorization": f"Bearer {res.json()['access_token']}"}
+
+
+def test_e2e_06_real_grade_triggers_external_validation_recommendations_in_report(
+    db_session: Session,
+):
+    """
+    Covers: real grades -> external_validation recs -> tutor report.
+    """
+    uid = uuid.uuid4()
+    password = "pw"
+
+    role_tutor = _ensure_role(db_session, "Tutor")
+    role_student = _ensure_role(db_session, "Student")
+
+    tutor_user = User(
+        id=uuid.uuid4(),
+        email=f"t6_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_tutor.id,
+    )
+    student_user = User(
+        id=uuid.uuid4(),
+        email=f"s6_{uid}@example.com",
+        hashed_password=get_password_hash(password),
+        is_active=True,
+        role_id=role_student.id,
+    )
+    db_session.add_all([tutor_user, student_user])
+    db_session.flush()
+
+    tutor = Tutor(user_id=tutor_user.id, display_name="Tutor E2E-06")
+
+    year = AcademicYear(
+        name=f"2025-2026-{uid}",
+        start_date=date(2025, 9, 1),
+        end_date=date(2026, 6, 30),
+    )
+    term = Term(academic_year_id=year.id, code="T1", name="Term 1")
+    subject = Subject(name=f"Subject E2E-06 {uid}", tutor_id=tutor_user.id)
+    db_session.add_all([tutor, year, term, subject])
+    db_session.flush()
+
+    student = Student(user_id=student_user.id, subject_id=subject.id)
+    db_session.add(student)
+    db_session.flush()
+
+    _ensure_activity_type(db_session, "QUIZ")
+
+    microconcept = MicroConcept(
+        id=uuid.uuid4(),
+        subject_id=subject.id,
+        term_id=term.id,
+        code="MC-E2E-06",
+        name="Concepto E2E-06",
+        description="Microconcepto para validación externa",
+        active=True,
+    )
+    db_session.add(microconcept)
+    db_session.flush()
+
+    now = datetime.utcnow()
+    db_session.add(
+        MetricAggregate(
+            id=uuid.uuid4(),
+            student_id=student.id,
+            scope_type="subject",
+            scope_id=subject.id,
+            window_start=now - timedelta(days=30),
+            window_end=now,
+            accuracy=0.7,
+            first_attempt_accuracy=0.7,
+            error_rate=0.3,
+            median_response_time_ms=8000,
+            attempts_per_item_avg=1.1,
+            hint_rate=0.05,
+            abandon_rate=0.0,
+            computed_at=now,
+        )
+    )
+    db_session.add(
+        MasteryState(
+            id=uuid.uuid4(),
+            student_id=student.id,
+            microconcept_id=microconcept.id,
+            mastery_score=0.9,
+            status="dominant",
+            last_practice_at=now - timedelta(days=2),
+            recommended_next_review_at=now + timedelta(days=7),
+            updated_at=now,
+        )
+    )
+    db_session.commit()
+
+    tutor_headers = _login(tutor_user.email, password)
+
+    # 1) Registrar una calificación real baja, sin etiquetar, para disparar external_validation.
+    grade_res = client.post(
+        "/api/v1/grades",
+        json={
+            "student_id": str(student.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "assessment_date": date.today().isoformat(),
+            "grade_value": 4.0,
+            "grading_scale": "0-10",
+            "notes": "E2E-06 grade",
+            "scope_tags": [],
+        },
+        headers=tutor_headers,
+    )
+    assert grade_res.status_code == 201
+
+    # 2) Generar informe (incluye grades + recomendaciones).
+    report_res = client.post(
+        f"/api/v1/reports/students/{student.id}/generate",
+        params={
+            "tutor_id": str(tutor.id),
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "generate_recommendations": "true",
+        },
+        headers=tutor_headers,
+    )
+    assert report_res.status_code == 201
+    report = report_res.json()
+
+    assert any(s["section_type"] == "real_grades" for s in report["sections"])
+    rec_section = next(s for s in report["sections"] if s["section_type"] == "recommendations")
+    pending = rec_section["data"]["pending"]
+    assert pending
+
+    external = [r for r in pending if r.get("category") == "external_validation"]
+    assert external
+    external_codes = {r.get("rule_id") for r in external}
+    assert "R33" in external_codes
+    assert "R31" in external_codes
+
+    # 3) El endpoint de recomendaciones también debe reflejar la categoría.
+    recs_res = client.get(
+        f"/api/v1/recommendations/students/{student.id}",
+        params={
+            "subject_id": str(subject.id),
+            "term_id": str(term.id),
+            "status_filter": "pending",
+            "generate": "false",
+        },
+        headers=tutor_headers,
+    )
+    assert recs_res.status_code == 200
+    recs = recs_res.json()
+    assert recs
+    assert any(r.get("category") == "external_validation" for r in recs)

--- a/docs/technical/06_sprints/31_Runbook_E2E-06_Sprint_6_Dia_7.md
+++ b/docs/technical/06_sprints/31_Runbook_E2E-06_Sprint_6_Dia_7.md
@@ -1,0 +1,69 @@
+# Documento 31 — Runbook E2E-06 (Sprint 6 Día 7)
+
+## Objetivo
+
+Ejecutar y validar el flujo E2E-06 de Sprint 6:
+
+1) registrar una calificación real (nota) por parte del tutor
+2) disparar recomendaciones `external_validation` (R31–R40) en base a esa nota
+3) verificar que el informe del tutor refleja dichas recomendaciones (código + categoría)
+
+## Pre-requisitos
+
+- Docker + Docker Compose funcionando.
+- Servicios arriba: `db` y `backend` (y `frontend` para validación UI).
+- Migraciones aplicadas y seed cargado.
+
+## Credenciales seed (dev)
+
+- Tutor: `tutor@decies.com` / `decies`
+- Estudiante: `student@decies.com` / `decies`
+
+## Inicialización rápida de DB (Docker)
+
+1. Levanta entorno:
+   - `make dev-up`
+   - o Windows PowerShell: `powershell -ExecutionPolicy Bypass -File .\scripts\ps\dev-up.ps1`
+
+2. Aplica migraciones:
+   - Windows PowerShell: `powershell -ExecutionPolicy Bypass -File .\scripts\ps\db-migrate.ps1`
+   - Alternativa directa: `docker compose -f docker-compose.dev.yml exec -T backend sh -lc "python -m alembic upgrade head"`
+
+3. Carga seed:
+   - Windows PowerShell: `powershell -ExecutionPolicy Bypass -File .\scripts\ps\db-seed.ps1`
+   - Alternativa directa: `docker compose -f docker-compose.dev.yml exec -T backend sh -lc "python seed.py"`
+
+## E2E-06 (tests)
+
+Ejecuta el test E2E-06 en el contenedor `backend`:
+
+- `docker compose -f docker-compose.dev.yml exec -T backend sh -lc "pytest -q tests/e2e/test_e2e_06_external_validation_report.py -vv"`
+
+## Flujo E2E-06 (UI)
+
+### Tutor: registrar nota real
+
+1. Abre `http://localhost:3000/tutor`.
+2. Inicia sesión con el tutor seed.
+3. Selecciona contexto (asignatura, trimestre, alumno).
+4. Tab **Notas / Calificaciones**:
+   - registra una calificación baja (p.ej. `4.0` en escala `0-10`)
+   - opcionalmente deja el alcance sin etiquetas (esto dispara `R33`)
+
+### Tutor: verificar recomendaciones en informe
+
+1. Tab **Informes**: pulsa **Generar informe**.
+2. Verifica:
+   - sección **Calificaciones** incluye la nota registrada
+   - sección **Recomendaciones activas** incluye al menos una recomendación de categoría `external_validation` (R31–R40)
+   - sección **Impacto de recomendaciones** refleja metadatos (código/categoría) cuando haya recomendaciones aceptadas con outcome
+
+## Endpoints clave (referencia)
+
+- Notas reales:
+  - `POST /api/v1/grades`
+- Informe tutor:
+  - `POST /api/v1/reports/students/{student_id}/generate?tutor_id=...&subject_id=...&term_id=...&generate_recommendations=true`
+- Recomendaciones:
+  - `GET /api/v1/recommendations/students/{student_id}?subject_id=...&term_id=...&status_filter=pending&generate=false`
+

--- a/docs/technical/06_sprints/README.md
+++ b/docs/technical/06_sprints/README.md
@@ -9,3 +9,4 @@
 - `docs/technical/06_sprints/27_Desglose_Diario_Sprint_3_V1.md`
 - `docs/technical/06_sprints/28_Runbook_E2E-03_Sprint_3_Dia_7.md`
 - `docs/technical/06_sprints/30_Runbook_E2E-05_Sprint_5_Dia_7.md`
+- `docs/technical/06_sprints/31_Runbook_E2E-06_Sprint_6_Dia_7.md`


### PR DESCRIPTION
Adds automated E2E-06 coverage for external_validation recommendations driven by RealGrade and documents the runbook in docs/technical/06_sprints.

Fixes #92