### PR TITLE
feat(recommendations): scope instances to subject/term

### DIFF
--- a/backend/alembic/versions/26dccb19549f_recommendation_context_and_catalog_fk.py
+++ b/backend/alembic/versions/26dccb19549f_recommendation_context_and_catalog_fk.py
@@ -1,0 +1,128 @@
+"""recommendation context and catalog fk
+
+Revision ID: 26dccb19549f
+Revises: b3cfe90abd0c
+Create Date: 2025-12-21 00:24:12.775383
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "26dccb19549f"
+down_revision: str | None = "b3cfe90abd0c"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column("recommendation_instances", sa.Column("subject_id", sa.UUID(), nullable=True))
+    op.add_column("recommendation_instances", sa.Column("term_id", sa.UUID(), nullable=True))
+    op.add_column("recommendation_instances", sa.Column("topic_id", sa.UUID(), nullable=True))
+    op.add_column(
+        "recommendation_instances",
+        sa.Column("recommendation_code", sa.String(), nullable=True),
+    )
+
+    op.create_foreign_key(
+        "recommendation_instances_subject_id_fkey",
+        "recommendation_instances",
+        "subjects",
+        ["subject_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "recommendation_instances_term_id_fkey",
+        "recommendation_instances",
+        "terms",
+        ["term_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "recommendation_instances_topic_id_fkey",
+        "recommendation_instances",
+        "topics",
+        ["topic_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "recommendation_instances_recommendation_code_fkey",
+        "recommendation_instances",
+        "recommendation_catalog",
+        ["recommendation_code"],
+        ["code"],
+        ondelete="RESTRICT",
+    )
+
+    op.execute(
+        """
+        UPDATE recommendation_instances AS ri
+        SET subject_id = s.subject_id
+        FROM students AS s
+        WHERE ri.student_id = s.id
+          AND ri.subject_id IS NULL
+          AND s.subject_id IS NOT NULL
+        """
+    )
+
+    op.execute(
+        """
+        WITH latest_session AS (
+            SELECT DISTINCT ON (student_id) student_id, term_id
+            FROM activity_sessions
+            WHERE term_id IS NOT NULL
+            ORDER BY student_id, started_at DESC
+        )
+        UPDATE recommendation_instances AS ri
+        SET term_id = ls.term_id
+        FROM latest_session AS ls
+        WHERE ri.student_id = ls.student_id
+          AND ri.term_id IS NULL
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE recommendation_instances AS ri
+        SET recommendation_code = ri.rule_id
+        WHERE ri.recommendation_code IS NULL
+          AND ri.rule_id ~ '^R\\d\\d$'
+          AND EXISTS (
+              SELECT 1 FROM recommendation_catalog AS rc WHERE rc.code = ri.rule_id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "recommendation_instances_recommendation_code_fkey",
+        "recommendation_instances",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "recommendation_instances_topic_id_fkey",
+        "recommendation_instances",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "recommendation_instances_term_id_fkey",
+        "recommendation_instances",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "recommendation_instances_subject_id_fkey",
+        "recommendation_instances",
+        type_="foreignkey",
+    )
+
+    op.drop_column("recommendation_instances", "recommendation_code")
+    op.drop_column("recommendation_instances", "topic_id")
+    op.drop_column("recommendation_instances", "term_id")
+    op.drop_column("recommendation_instances", "subject_id")

--- a/backend/app/models/recommendation.py
+++ b/backend/app/models/recommendation.py
@@ -46,6 +46,36 @@ class RecommendationInstance(Base):
         nullable=False,
     )
 
+    subject_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "subjects.id",
+            name="recommendation_instances_subject_id_fkey",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+    )
+
+    term_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "terms.id",
+            name="recommendation_instances_term_id_fkey",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+    )
+
+    topic_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "topics.id",
+            name="recommendation_instances_topic_id_fkey",
+            ondelete="SET NULL",
+        ),
+        nullable=True,
+    )
+
     # Optional: Recommendations can be specific to a microconcept, topic, subject, etc.
     microconcept_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
@@ -58,6 +88,15 @@ class RecommendationInstance(Base):
     )
 
     rule_id: Mapped[str] = mapped_column(String, nullable=False)  # e.g., "R01", "R11"
+    recommendation_code: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey(
+            "recommendation_catalog.code",
+            name="recommendation_instances_recommendation_code_fkey",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+    )
     priority: Mapped[RecommendationPriority] = mapped_column(
         Enum(RecommendationPriority, name="recommendation_priority", create_type=False),
         nullable=False,

--- a/backend/app/routers/recommendations.py
+++ b/backend/app/routers/recommendations.py
@@ -2,6 +2,7 @@ import uuid
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import or_
 from sqlalchemy.orm import Session, selectinload
 
 from app.core.db import get_db
@@ -68,6 +69,18 @@ def get_student_recommendations(
             selectinload(RecommendationInstance.outcome),
         )
         .filter(RecommendationInstance.student_id == student_id)
+        .filter(
+            or_(
+                RecommendationInstance.subject_id == subject_id,
+                RecommendationInstance.subject_id.is_(None),
+            )
+        )
+        .filter(
+            or_(
+                RecommendationInstance.term_id == term_id,
+                RecommendationInstance.term_id.is_(None),
+            )
+        )
     )
 
     if status_filter != "all":

--- a/backend/app/schemas/recommendation.py
+++ b/backend/app/schemas/recommendation.py
@@ -46,8 +46,12 @@ class TutorDecisionResponse(TutorDecisionBase):
 
 class RecommendationInstanceBase(BaseModel):
     student_id: uuid.UUID
+    subject_id: uuid.UUID | None = None
+    term_id: uuid.UUID | None = None
+    topic_id: uuid.UUID | None = None
     microconcept_id: Optional[uuid.UUID] = None
     rule_id: str
+    recommendation_code: str | None = None
     category: Optional[str] = None
     priority: str
     status: str

--- a/backend/app/services/recommendation_outcome_service.py
+++ b/backend/app/services/recommendation_outcome_service.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session, selectinload
 
 from app.models.activity import LearningEvent
@@ -166,6 +167,14 @@ class RecommendationOutcomeService:
             .filter(
                 RecommendationInstance.student_id == student_id,
                 RecommendationInstance.status == RecommendationStatus.ACCEPTED,
+                or_(
+                    RecommendationInstance.subject_id == subject_id,
+                    RecommendationInstance.subject_id.is_(None),
+                ),
+                or_(
+                    RecommendationInstance.term_id == term_id,
+                    RecommendationInstance.term_id.is_(None),
+                ),
             )
             .all()
         )

--- a/backend/app/services/recommendation_service.py
+++ b/backend/app/services/recommendation_service.py
@@ -137,6 +137,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R01",
                 title="Refuerzo General Necesario",
                 description=(
@@ -179,6 +181,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R02",
                 title=f"Consolidar: {mc_name}",
                 description=(
@@ -239,6 +243,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R03",
                 title="Repaso espaciado de microconceptos dominados",
                 description=(
@@ -260,6 +266,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R04",
                 title="Reducir carga de nuevos conceptos",
                 description=(
@@ -311,6 +319,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R06",
                 title="Reorganizar orden del trimestre",
                 description=(
@@ -343,6 +353,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R07",
                 title=f"Repetición inmediata: {mc_name}",
                 description=(
@@ -388,6 +400,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R08",
                 title="Introducir microevaluaciones frecuentes",
                 description=(
@@ -423,6 +437,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R09",
                 title="Separar conceptos confundidos",
                 description=(
@@ -448,6 +464,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R10",
                 title="Simplificar dificultad temporalmente",
                 description=(
@@ -487,6 +505,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R11",
                     title=f"Refuerzo: {mc_name}",
                     description=(
@@ -547,6 +567,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R12",
                 title="Limitar uso de pistas",
                 description=(
@@ -572,6 +594,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R13",
                     title="Sustituir repaso pasivo por práctica activa",
                     description=(
@@ -602,6 +626,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R14",
                 title="Introducir intercalado",
                 description=(
@@ -634,6 +660,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R15",
                     title="Volver a práctica bloqueada",
                     description=(
@@ -688,6 +716,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R16",
                     title="Cambiar tipo de actividad",
                     description=(
@@ -735,6 +765,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R17",
                 title=f"Aumentar ejemplos concretos: {mc_name}",
                 description=(
@@ -771,6 +803,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R18",
                 title="Introducir variabilidad controlada",
                 description=(
@@ -802,6 +836,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R19",
                     title="Añadir explicación tras error",
                     description=(
@@ -834,6 +870,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R20",
                 title="Reducir explicación anticipada",
                 description=(
@@ -918,6 +956,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R05",
                     title=f"Reforzar prerequisito: {prereq_name}",
                     description=(
@@ -964,6 +1004,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R21",
                 title="Posible Fatiga o Duda",
                 description=(
@@ -1068,6 +1110,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R33",
                     title="Etiquetado por tutor",
                     description=(
@@ -1101,6 +1145,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R31",
                     title="Ejercicios tipo examen",
                     description=(
@@ -1149,6 +1195,8 @@ class RecommendationService:
                     rec = self._create_or_get_recommendation(
                         db,
                         student_id=student_id,
+                        subject_id=subject_id,
+                        term_id=term_id,
                         rule_id="R35",
                         title=f"Priorizar conceptos clave del examen: {mc_name}",
                         description=(
@@ -1188,6 +1236,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R36",
                     title="Reducir confianza excesiva",
                     description=(
@@ -1225,6 +1275,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R32",
                     title="Revisar alineación temario",
                     description=(
@@ -1251,6 +1303,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R34",
                     title="Reforzar transferencia",
                     description=(
@@ -1309,6 +1363,8 @@ class RecommendationService:
                     rec = self._create_or_get_recommendation(
                         db,
                         student_id=student_id,
+                        subject_id=subject_id,
+                        term_id=term_id,
                         rule_id="R37",
                         title="Revisar consistencia entre sesiones",
                         description=(
@@ -1347,6 +1403,8 @@ class RecommendationService:
                     rec = self._create_or_get_recommendation(
                         db,
                         student_id=student_id,
+                        subject_id=subject_id,
+                        term_id=term_id,
                         rule_id="R38",
                         title="Activar revisión tutor–alumno",
                         description=(
@@ -1380,6 +1438,8 @@ class RecommendationService:
                     rec = self._create_or_get_recommendation(
                         db,
                         student_id=student_id,
+                        subject_id=subject_id,
+                        term_id=term_id,
                         rule_id="R40",
                         title="Reevaluar tras no mejora",
                         description=(
@@ -1418,6 +1478,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R39",
                     title="Mantener estrategia actual",
                     description=(
@@ -1499,6 +1561,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R22",
                 title="Aumentar sesiones cortas",
                 description=(
@@ -1529,6 +1593,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R23",
                 title="Introducir descansos",
                 description=(
@@ -1562,6 +1628,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R24",
                     title="Ajustar ritmo",
                     description=(
@@ -1593,6 +1661,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R25",
                     title="Añadir pausa reflexiva",
                     description=(
@@ -1624,6 +1694,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R26",
                     title="Aumentar automatización",
                     description=(
@@ -1655,6 +1727,8 @@ class RecommendationService:
                 rec = self._create_or_get_recommendation(
                     db,
                     student_id=student_id,
+                    subject_id=subject_id,
+                    term_id=term_id,
                     rule_id="R27",
                     title="Reducir volumen diario",
                     description=(
@@ -1696,6 +1770,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R28",
                 title="Incrementar volumen",
                 description=(
@@ -1733,6 +1809,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R29",
                 title="Ajustar dificultad",
                 description=(
@@ -1769,6 +1847,8 @@ class RecommendationService:
             rec = self._create_or_get_recommendation(
                 db,
                 student_id=student_id,
+                subject_id=subject_id,
+                term_id=term_id,
                 rule_id="R30",
                 title="Alternar días intensivos y ligeros",
                 description=(
@@ -1805,13 +1885,17 @@ class RecommendationService:
     def _create_or_get_recommendation(
         self,
         db: Session,
+        *,
         student_id: uuid.UUID,
+        subject_id: uuid.UUID,
+        term_id: uuid.UUID,
         rule_id: str,
         title: str,
         description: str,
         priority: RecommendationPriority,
         evidence: list[RecommendationEvidenceCreate],
         microconcept_id: Optional[uuid.UUID] = None,
+        topic_id: Optional[uuid.UUID] = None,
     ) -> Optional[RecommendationInstance]:
         if rule_id not in self._get_catalog_codes(db):
             raise ValueError(
@@ -1824,6 +1908,8 @@ class RecommendationService:
             db.query(RecommendationInstance)
             .filter(
                 RecommendationInstance.student_id == student_id,
+                RecommendationInstance.subject_id == subject_id,
+                RecommendationInstance.term_id == term_id,
                 RecommendationInstance.rule_id == rule_id,
                 RecommendationInstance.status == RecommendationStatus.PENDING,
                 RecommendationInstance.microconcept_id == microconcept_id,
@@ -1838,8 +1924,12 @@ class RecommendationService:
         new_rec = RecommendationInstance(
             id=uuid.uuid4(),
             student_id=student_id,
+            subject_id=subject_id,
+            term_id=term_id,
+            topic_id=topic_id,
             microconcept_id=microconcept_id,
             rule_id=rule_id,
+            recommendation_code=rule_id,
             priority=priority,
             status=RecommendationStatus.PENDING,
             title=title,

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -131,6 +131,14 @@ class ReportService:
             .filter(
                 RecommendationInstance.student_id == student_id,
                 RecommendationInstance.status == RecommendationStatus.PENDING,
+                or_(
+                    RecommendationInstance.subject_id == subject_id,
+                    RecommendationInstance.subject_id.is_(None),
+                ),
+                or_(
+                    RecommendationInstance.term_id == term_id,
+                    RecommendationInstance.term_id.is_(None),
+                ),
             )
             .order_by(RecommendationInstance.priority, RecommendationInstance.generated_at.desc())
             .all()
@@ -154,8 +162,17 @@ class ReportService:
                 RecommendationInstance.student_id == student_id,
                 RecommendationInstance.status == RecommendationStatus.ACCEPTED,
                 or_(
-                    RecommendationInstance.microconcept_id.is_(None),
-                    and_(MicroConcept.subject_id == subject_id, MicroConcept.term_id == term_id),
+                    and_(
+                        RecommendationInstance.subject_id == subject_id,
+                        RecommendationInstance.term_id == term_id,
+                    ),
+                    and_(
+                        RecommendationInstance.subject_id.is_(None),
+                        RecommendationInstance.term_id.is_(None),
+                        RecommendationInstance.microconcept_id.is_not(None),
+                        MicroConcept.subject_id == subject_id,
+                        MicroConcept.term_id == term_id,
+                    ),
                 ),
             )
             .order_by(RecommendationInstance.updated_at.desc())

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -796,6 +796,8 @@ def test_recommendation_catalog_guardrail_blocks_unknown_rule(db_session, contex
         recommendation_service._create_or_get_recommendation(
             db_session,
             student_id=student.id,
+            subject_id=context["subject"].id,
+            term_id=context["term"].id,
             rule_id="RX99",
             title="Invalid",
             description="Invalid",


### PR DESCRIPTION
Adds subject/term/topic context + catalog FK to recommendation_instances, with migration backfill and scoped queries for reports/outcomes.

Fixes #101