### PR TITLE
feat(admin): add RBAC and minimal endpoints

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -79,3 +79,11 @@ def get_current_student(
     if not student:
         raise HTTPException(status_code=404, detail="Student not found")
     return student
+
+
+def get_current_admin(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+) -> User:
+    require_roles(db, current_user, {"admin"})
+    return current_user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.v1 import auth, events
 from app.core.db import get_db
 from app.routers import (
     activity,
+    admin,
     catalog,
     content,
     grades,
@@ -38,6 +39,7 @@ app.include_router(recommendations.router, prefix="/api/v1")
 app.include_router(reports.router, prefix="/api/v1")
 app.include_router(catalog.router, prefix="/api/v1")
 app.include_router(grades.router, prefix="/api/v1")
+app.include_router(admin.router, prefix="/api/v1")
 
 # CORS middleware
 app.add_middleware(

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,112 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.db import get_db
+from app.core.deps import get_current_admin
+from app.models.activity import ActivityType
+from app.models.item import Item
+from app.models.recommendation_catalog import RecommendationCatalog
+from app.models.user import User
+from app.schemas.activity import ActivityTypeResponse
+from app.schemas.admin import (
+    AdminActivityTypeUpdate,
+    AdminItemSummary,
+    AdminRecommendationCatalogResponse,
+    AdminRecommendationCatalogUpdate,
+)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/items", response_model=list[AdminItemSummary])
+def list_items(
+    limit: int = 50,
+    offset: int = 0,
+    content_upload_id: uuid.UUID | None = None,
+    microconcept_id: uuid.UUID | None = None,
+    is_active: bool | None = None,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(get_current_admin),
+):
+    query = db.query(Item)
+    if content_upload_id:
+        query = query.filter(Item.content_upload_id == content_upload_id)
+    if microconcept_id:
+        query = query.filter(Item.microconcept_id == microconcept_id)
+    if is_active is not None:
+        query = query.filter(Item.is_active == is_active)
+    return query.order_by(Item.created_at.desc().nullslast()).offset(offset).limit(limit).all()
+
+
+@router.get("/recommendation-catalog", response_model=list[AdminRecommendationCatalogResponse])
+def list_recommendation_catalog(
+    active: bool | None = None,
+    category: str | None = None,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(get_current_admin),
+):
+    query = db.query(RecommendationCatalog)
+    if active is not None:
+        query = query.filter(RecommendationCatalog.active == active)
+    if category:
+        query = query.filter(RecommendationCatalog.category == category)
+    return query.order_by(RecommendationCatalog.code).all()
+
+
+@router.patch(
+    "/recommendation-catalog/{code}",
+    response_model=AdminRecommendationCatalogResponse,
+)
+def update_recommendation_catalog(
+    code: str,
+    payload: AdminRecommendationCatalogUpdate,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(get_current_admin),
+):
+    row = db.query(RecommendationCatalog).filter(RecommendationCatalog.code == code).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Recommendation catalog entry not found")
+
+    data = payload.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(row, key, value)
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/activity-types", response_model=list[ActivityTypeResponse])
+def list_activity_types(
+    active: bool | None = None,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(get_current_admin),
+):
+    query = db.query(ActivityType)
+    if active is not None:
+        query = query.filter(ActivityType.active == active)
+    return query.order_by(ActivityType.code).all()
+
+
+@router.patch("/activity-types/{activity_type_id}", response_model=ActivityTypeResponse)
+def update_activity_type(
+    activity_type_id: uuid.UUID,
+    payload: AdminActivityTypeUpdate,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(get_current_admin),
+):
+    row = db.get(ActivityType, activity_type_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Activity type not found")
+
+    data = payload.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(row, key, value)
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AdminItemSummary(BaseModel):
+    id: uuid.UUID
+    content_upload_id: uuid.UUID
+    microconcept_id: uuid.UUID | None = None
+    type: str
+    stem: str
+    is_active: bool
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminRecommendationCatalogResponse(BaseModel):
+    code: str
+    title: str
+    description: str
+    category: str
+    active: bool
+    catalog_version: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminRecommendationCatalogUpdate(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    category: str | None = None
+    active: bool | None = None
+    catalog_version: str | None = None
+
+
+class AdminActivityTypeUpdate(BaseModel):
+    name: str | None = None
+    active: bool | None = None

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -45,6 +45,12 @@ def seed_db():
             db.add(role_student)
             logger.info("Created Role: student")
 
+        role_admin = db.query(Role).filter_by(name="admin").first()
+        if not role_admin:
+            role_admin = Role(id=uuid.uuid4(), name="admin", description="Admin Role")
+            db.add(role_admin)
+            logger.info("Created Role: admin")
+
         db.commit()
 
         # 2. Create Tutor User
@@ -93,6 +99,26 @@ def seed_db():
         elif not user_student.hashed_password.startswith("$pbkdf2-sha256$"):
             user_student.hashed_password = get_password_hash(default_password)
             logger.info("Updated Student password hash")
+
+        db.commit()
+
+        # 3b. Create Admin User
+        admin_email = "admin@decies.com"
+        user_admin = db.query(User).filter_by(email=admin_email).first()
+        if not user_admin:
+            user_admin = User(
+                id=uuid.uuid4(),
+                email=admin_email,
+                hashed_password=get_password_hash(default_password),
+                full_name="Admin Decies",
+                role_id=role_admin.id,
+                is_active=True,
+            )
+            db.add(user_admin)
+            logger.info(f"Created User: {admin_email}")
+        elif not user_admin.hashed_password.startswith("$pbkdf2-sha256$"):
+            user_admin.hashed_password = get_password_hash(default_password)
+            logger.info("Updated Admin password hash")
 
         db.commit()
 

--- a/backend/tests/test_admin_rbac.py
+++ b/backend/tests/test_admin_rbac.py
@@ -1,0 +1,84 @@
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _login(email: str, password: str) -> dict[str, str]:
+    token_res = client.post(
+        "/api/v1/login/access-token",
+        json={"email": email, "password": password},
+    )
+    assert token_res.status_code == 200
+    token = token_res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_admin_endpoints_rbac_list_catalog_and_items():
+    admin_headers = _login("admin@decies.com", "decies")
+    tutor_headers = _login("tutor@decies.com", "decies")
+    student_headers = _login("student@decies.com", "decies")
+
+    res = client.get("/api/v1/admin/recommendation-catalog", headers=admin_headers)
+    assert res.status_code == 200
+    assert isinstance(res.json(), list)
+
+    res = client.get("/api/v1/admin/recommendation-catalog", headers=tutor_headers)
+    assert res.status_code == 403
+
+    res = client.get("/api/v1/admin/recommendation-catalog", headers=student_headers)
+    assert res.status_code == 403
+
+    res = client.get("/api/v1/admin/items", headers=admin_headers)
+    assert res.status_code == 200
+    assert isinstance(res.json(), list)
+
+
+def test_admin_endpoints_rbac_patch_catalog():
+    admin_headers = _login("admin@decies.com", "decies")
+    tutor_headers = _login("tutor@decies.com", "decies")
+
+    catalog = client.get("/api/v1/admin/recommendation-catalog", headers=admin_headers).json()
+    assert catalog
+    code = catalog[0]["code"]
+
+    res = client.patch(
+        f"/api/v1/admin/recommendation-catalog/{code}",
+        headers=admin_headers,
+        json={"active": catalog[0]["active"]},
+    )
+    assert res.status_code == 200
+    assert res.json()["code"] == code
+
+    res = client.patch(
+        f"/api/v1/admin/recommendation-catalog/{code}",
+        headers=tutor_headers,
+        json={"active": catalog[0]["active"]},
+    )
+    assert res.status_code == 403
+
+
+def test_admin_endpoints_rbac_patch_activity_type():
+    admin_headers = _login("admin@decies.com", "decies")
+    tutor_headers = _login("tutor@decies.com", "decies")
+
+    types = client.get("/api/v1/admin/activity-types", headers=admin_headers).json()
+    assert types
+    activity_type_id = uuid.UUID(types[0]["id"])
+
+    res = client.patch(
+        f"/api/v1/admin/activity-types/{activity_type_id}",
+        headers=admin_headers,
+        json={"active": types[0]["active"]},
+    )
+    assert res.status_code == 200
+
+    res = client.patch(
+        f"/api/v1/admin/activity-types/{activity_type_id}",
+        headers=tutor_headers,
+        json={"active": types[0]["active"]},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
Adds admin role seeding, admin-only endpoints (items, recommendation catalog, activity types), and RBAC tests.

Fixes #103