### PR TITLE
feat(content): upload processing status

### DIFF
--- a/backend/alembic/versions/3f5f2c9e9b71_content_upload_processing_status.py
+++ b/backend/alembic/versions/3f5f2c9e9b71_content_upload_processing_status.py
@@ -1,0 +1,36 @@
+"""content_uploads processing status fields
+
+Revision ID: 3f5f2c9e9b71
+Revises: e88f5a4c0762
+Create Date: 2025-12-21 13:22:00.000000
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "3f5f2c9e9b71"
+down_revision: str | None = "e88f5a4c0762"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "content_uploads", sa.Column("processing_status", sa.String(length=20), nullable=True)
+    )
+    op.add_column(
+        "content_uploads", sa.Column("processing_job_id", sa.String(length=128), nullable=True)
+    )
+    op.add_column("content_uploads", sa.Column("processing_error", sa.Text(), nullable=True))
+    op.add_column("content_uploads", sa.Column("processed_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("content_uploads", "processed_at")
+    op.drop_column("content_uploads", "processing_error")
+    op.drop_column("content_uploads", "processing_job_id")
+    op.drop_column("content_uploads", "processing_status")

--- a/backend/app/models/content.py
+++ b/backend/app/models/content.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from enum import Enum as PyEnum
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, text
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -50,6 +50,10 @@ class ContentUpload(Base):
     file_name: Mapped[str] = mapped_column(String, nullable=False)
     mime_type: Mapped[str] = mapped_column(String, nullable=False)
     page_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    processing_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    processing_job_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    processing_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=True
     )

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime
 
 from app.core.db import SessionLocal
+from app.models.content import ContentUpload
 from app.pipelines.processing import process_content_upload
 from app.services.metric_service import metric_service
 from app.services.recommendation_service import recommendation_service
@@ -15,7 +17,31 @@ def process_upload_job(upload_id: str) -> None:
     upload_uuid = uuid.UUID(upload_id)
     db = SessionLocal()
     try:
+        upload = db.query(ContentUpload).filter(ContentUpload.id == upload_uuid).first()
+        if upload:
+            upload.processing_status = "running"
+            upload.processing_error = None
+            upload.processed_at = None
+            db.add(upload)
+            db.commit()
+
         process_content_upload(db, upload_uuid)
+        upload = db.query(ContentUpload).filter(ContentUpload.id == upload_uuid).first()
+        if upload:
+            upload.processing_status = "succeeded"
+            upload.processing_error = None
+            upload.processed_at = datetime.utcnow()
+            db.add(upload)
+            db.commit()
+    except Exception as e:  # noqa: BLE001
+        db.rollback()
+        upload = db.query(ContentUpload).filter(ContentUpload.id == upload_uuid).first()
+        if upload:
+            upload.processing_status = "failed"
+            upload.processing_error = str(e)
+            db.add(upload)
+            db.commit()
+        raise
     finally:
         db.close()
 


### PR DESCRIPTION
Adds processing status tracking for content uploads (queued/running/succeeded/failed), stores job id/error/processed_at, updates background+RQ tasks, and adds GET /content/uploads/{id}/processing.

Fixes #114