### PR TITLE
fix(worker): start rq worker on rq 2.x

### DIFF
--- a/backend/app/workers/worker.py
+++ b/backend/app/workers/worker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from rq import Connection, Worker
+from rq import Worker
 
 from app.core.config import settings
 from app.core.queue import _get_redis_connection
@@ -12,9 +12,8 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     redis_connection = _get_redis_connection()
-    with Connection(redis_connection):
-        worker = Worker([settings.RQ_QUEUE_NAME])
-        worker.work()
+    worker = Worker([settings.RQ_QUEUE_NAME], connection=redis_connection)
+    worker.work()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
El contenedor decies-worker fallaba al arrancar con q 2.x por rom rq import Connection (API removida). Ajusta el entrypoint del worker para instanciar Worker(..., connection=redis_connection).

Validación local: import de pp.workers.worker OK.