### PR TITLE
feat(infra): add redis/worker health checks

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -30,6 +30,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
@@ -76,4 +85,4 @@ jobs:
         working-directory: backend
         run: |
           . .venv/bin/activate
-          DATABASE_URL="postgresql+psycopg2://decies:decies@localhost:5432/decies" uv run pytest -q
+          DATABASE_URL="postgresql+psycopg2://decies:decies@localhost:5432/decies" REDIS_URL="redis://localhost:6379/0" uv run pytest -q

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,12 +5,16 @@ Sprint 0 - Día 1: Health endpoint only
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from redis.exceptions import RedisError
+from rq import Worker
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.api.v1 import auth, events
+from app.core.config import settings
 from app.core.db import get_db
+from app.core.queue import _get_redis_connection
 from app.routers import (
     activity,
     admin,
@@ -83,3 +87,69 @@ def health_db(db: Session = Depends(get_db)):
         ) from exc
 
     return {"status": "ok", "db": "ok"}
+
+
+@app.get("/health/redis")
+def health_redis():
+    """Redis health check endpoint (used for async queue mode)."""
+    try:
+        redis_connection = _get_redis_connection()
+        redis_connection.ping()
+    except RedisError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "error",
+                "redis": "unavailable",
+                "error": str(exc),
+            },
+        ) from exc
+
+    return {"status": "ok", "redis": "ok"}
+
+
+@app.get("/health/worker")
+def health_worker():
+    """Worker health check endpoint (only meaningful when ASYNC_QUEUE_ENABLED=true)."""
+    if not settings.ASYNC_QUEUE_ENABLED:
+        return {"status": "skipped", "async_enabled": False}
+
+    try:
+        redis_connection = _get_redis_connection()
+        redis_connection.ping()
+        workers = Worker.all(connection=redis_connection)
+    except RedisError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "error",
+                "redis": "unavailable",
+                "error": str(exc),
+            },
+        ) from exc
+
+    active_workers = []
+    for worker in workers:
+        try:
+            if any(queue.name == settings.RQ_QUEUE_NAME for queue in worker.queues):
+                active_workers.append(worker.name)
+        except Exception:  # noqa: BLE001
+            active_workers.append(worker.name)
+
+    if not active_workers:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "error",
+                "worker": "unavailable",
+                "queue": settings.RQ_QUEUE_NAME,
+                "workers": 0,
+            },
+        )
+
+    return {
+        "status": "ok",
+        "async_enabled": True,
+        "queue": settings.RQ_QUEUE_NAME,
+        "workers": len(active_workers),
+    }

--- a/backend/tests/test_async_queue_health.py
+++ b/backend/tests/test_async_queue_health.py
@@ -1,0 +1,38 @@
+import uuid
+
+import pytest
+import redis
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.core.queue import enqueue_upload_processing
+from app.main import app
+
+
+def _redis_ping() -> None:
+    connection = redis.from_url(settings.REDIS_URL)
+    connection.ping()
+
+
+def test_health_redis_ok() -> None:
+    try:
+        _redis_ping()
+    except redis.exceptions.RedisError:
+        pytest.skip("Redis not available")
+
+    client = TestClient(app)
+    response = client.get("/health/redis")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["redis"] == "ok"
+
+
+def test_enqueue_upload_processing_returns_job_id() -> None:
+    try:
+        _redis_ping()
+    except redis.exceptions.RedisError:
+        pytest.skip("Redis not available")
+
+    job_id = enqueue_upload_processing(upload_id=uuid.uuid4())
+    assert job_id

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,11 @@ services:
       - "6379:6379"
     networks:
       - decies-network
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   backend:
     build:
@@ -52,7 +57,7 @@ services:
       db:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   worker:
@@ -74,8 +79,17 @@ services:
       db:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     command: python -m app.workers.worker
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import os, redis; r=redis.from_url(os.environ.get('REDIS_URL','redis://redis:6379/0')); r.ping(); print('ok')\"",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
 volumes:
   pgdata:

--- a/docs/runbooks/async-queue.md
+++ b/docs/runbooks/async-queue.md
@@ -50,3 +50,9 @@ Quita `ASYNC_QUEUE_ENABLED=true` (o ponlo en `false`) y reinicia:
 docker compose -f docker-compose.dev.yml restart backend
 ```
 
+## Healthchecks (API)
+
+- Redis: `GET http://localhost:8000/health/redis`
+- Worker (solo si `ASYNC_QUEUE_ENABLED=true`): `GET http://localhost:8000/health/worker`
+
+Nota: con `ASYNC_QUEUE_ENABLED=false`, `/health/worker` responde `status=skipped`.


### PR DESCRIPTION
Fixes #116

Incluye:
- API healthchecks: GET /health/redis y GET /health/worker (este último solo cuando ASYNC_QUEUE_ENABLED=true).
- Docker compose dev: healthchecks para edis y worker + depends_on espera a redis healthy.
- Backend CI: añade servicio Redis y exporta REDIS_URL en tests.
- Tests: smoke test de /health/redis + enqueue básico con RQ (skip si Redis no está disponible).