### PR TITLE
fix(repo): ignore local artifacts and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,10 @@ logs/
 docs/00_fundacion/
 docs/01_modelo_pedagogico/
 docs/03_planificacion/
-docs/15_Presentacion_y_Pitch_del_Proyecto_V1.md!frontend/src/lib/
+docs/15_Presentacion_y_Pitch_del_Proyecto_V1.md
+
+# Storage (local dev artefacts)
+backend/storage/uploads/
+
+# Local tool venvs
+.ruff-venv/


### PR DESCRIPTION
Fixes #129

- Corrige typo al final de .gitignore.
- Ignora artefactos de desarrollo: ackend/storage/uploads/ y .ruff-venv/.