### PR TITLE
fix(ci): run frontend checks for src/app

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -22,18 +22,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "frontend/package-lock.json"
 
       - name: Install dependencies
         working-directory: frontend
-        run: npm install
+        run: npm ci
 
       - name: Lint
         working-directory: frontend
         run: |
-          if [ -d "app" ] || [ -d "pages" ]; then
+          if [ -d "src/app" ] || [ -d "src/pages" ]; then
             npm run lint
           else
-            echo "Skip lint: no app/ or pages/ directory yet."
+            echo "Skip lint: no src/app or src/pages directory yet."
           fi
 
       - name: Test
@@ -43,8 +45,8 @@ jobs:
       - name: Build check
         working-directory: frontend
         run: |
-          if [ -d "app" ] || [ -d "pages" ]; then
+          if [ -d "src/app" ] || [ -d "src/pages" ]; then
             npm run build --if-present
           else
-            echo "Skip build: no app/ or pages/ directory yet."
+            echo "Skip build: no src/app or src/pages directory yet."
           fi


### PR DESCRIPTION
Fixes #123

- Frontend CI ahora detecta rontend/src/app / rontend/src/pages.
- Usa 
pm ci y cache de npm para reproducibilidad/velocidad.