### PR TITLE
docs(governance): define main/develop branching strategy

### DIFF
--- a/docs/07_gobierno/D-12_branching_strategy_main_develop.md
+++ b/docs/07_gobierno/D-12_branching_strategy_main_develop.md
@@ -1,0 +1,41 @@
+# D-12 — Estrategia de ramas (`main` / `develop`)
+
+## Contexto
+
+El repositorio usa dos ramas principales:
+
+- `develop`: integración continua de trabajo (features/fixes).
+- `main`: rama por defecto y base estable.
+
+Con el tiempo puede aparecer *drift* (diferencias grandes entre ramas), lo que:
+
+- rompe PRs automáticos (p.ej. Dependabot apuntando a una base desalineada),
+- dificulta mantener `main` verde,
+- complica aplicar fixes de seguridad en la rama por defecto.
+
+## Decisión
+
+1. **La rama por defecto se mantiene como `main`.**
+2. **Toda feature/fix se integra en `develop` vía PR** (base `develop`), siguiendo `CONTRIBUTING.md`.
+3. **Cadencia de “release sync”**:
+   - Abrir PR periódico `develop -> main` (merge commit recomendado).
+   - Objetivo: mantener `main` cerca de `develop` y en verde.
+4. **Fixes urgentes (hotfix/security)**:
+   - Si un fix debe caer en `main` primero (p.ej. alertas de seguridad en rama por defecto), se backportea a `develop` con un PR `main -> develop` o cherry-pick.
+5. **Dependabot (no security)**:
+   - PRs de updates regulares targetean `develop` para respetar el flujo.
+
+## Consecuencias
+
+- `main` se mantiene como referencia estable y rama por defecto (alerts/seguridad).
+- `develop` concentra el trabajo diario y reduce fricción de CI/PRs.
+- Evitamos PRs rotos por incompatibilidades entre dependencias y “base” desalineada.
+
+## Operativa mínima
+
+Checklist para sync `develop -> main`:
+
+1. CI verde en `develop`.
+2. Crear PR `develop` -> `main` con título tipo `chore(release): sync develop into main`.
+3. Merge (preferible merge commit) cuando CI esté verde.
+4. Crear PR `main` -> `develop` si hubo commits directos a `main` (security/hotfix), para mantener ambas ramas alineadas.

--- a/docs/07_gobierno/README.md
+++ b/docs/07_gobierno/README.md
@@ -5,4 +5,5 @@
 - `docs/07_gobierno/D-09_orden_scripts_init_db.md`
 - `docs/07_gobierno/D-10_ci_path_filters.md`
 - `docs/07_gobierno/D-11_recommendations_schema_alignment.md`
+- `docs/07_gobierno/D-12_branching_strategy_main_develop.md`
 - `docs/07_gobierno/24_Registro_de_Decisiones_y_Supuestos_V1.md`


### PR DESCRIPTION
Fixes #124

Adds decision record D-12 describing how to keep main (default) and develop aligned, including release-sync cadence and backporting security/hotfixes.