### PR TITLE
chore: remove temporary debug logging from seed.py

### DIFF
--- a/backend/seed.py
+++ b/backend/seed.py
@@ -191,17 +191,6 @@ def seed_db():
 
         db.commit()
 
-        # Log the exact relationship for debugging
-        logger.info("Student-Subject Relationship Debug:")
-        logger.info(f"  Student ID: {student_profile.id}")
-        logger.info(f"  Student user_id: {student_profile.user_id}")
-        logger.info(f"  Student subject_id: {student_profile.subject_id}")
-        logger.info(f"  Subject ID: {subject.id}")
-        logger.info(f"  Subject tutor_id: {subject.tutor_id}")
-        logger.info(f"  Tutor User ID: {user_tutor.id}")
-        is_valid = student_profile.subject_id == subject.id and subject.tutor_id == user_tutor.id
-        logger.info(f"  Relationship valid: {is_valid}")
-
         # 6. Create Activity Types (Day 4)
         activity_types_data = [
             ("QUIZ", "Quiz Interactivo"),


### PR DESCRIPTION
## Description

Removes the temporary debug logging that was added to seed.py during Sprint 8 Day 1 troubleshooting.

## Changes

- Removed Student-Subject relationship debug logging section (11 lines)
- This logging was added to investigate test failures
- All tests now pass, so this logging is no longer needed

## Related

- PR #159 (Sprint 8 Day 1)
- Issue #160 (catalog/students endpoint investigation)

## Testing

-  Linting passes
-  Formatting passes
-  No functional changes, only logging removal