### PR TITLE
feat: Sprint 8 Day 2 - Multi-game pipeline

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_game_code_to_llm_runs.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_game_code_to_llm_runs.py
@@ -8,9 +8,9 @@ Create Date: 2025-12-23 20:59:00.000000
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "a1b2c3d4e5f6"

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_game_code_to_llm_runs.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_game_code_to_llm_runs.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "a1b2c3d4e5f6"
-down_revision: Union[str, None] = "fee3346a2bfe"
+down_revision: Union[str, None] = "18617bb11e18"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_game_code_to_llm_runs.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_game_code_to_llm_runs.py
@@ -1,0 +1,29 @@
+"""add game_code to llm_runs
+
+Revision ID: a1b2c3d4e5f6
+Revises: fee3346a2bfe
+Create Date: 2025-12-23 20:59:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "fee3346a2bfe"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add game_code column to llm_runs table
+    op.add_column("llm_runs", sa.Column("game_code", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    # Remove game_code column from llm_runs table
+    op.drop_column("llm_runs", "game_code")

--- a/backend/app/models/llm_run.py
+++ b/backend/app/models/llm_run.py
@@ -71,6 +71,7 @@ class LLMRun(Base):
         default="V1",
         server_default=text("'V1'"),
     )
+    game_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
     prompt_tokens: Mapped[int] = mapped_column(Integer, default=0)
     completion_tokens: Mapped[int] = mapped_column(Integer, default=0)
     total_cost: Mapped[float] = mapped_column(default=0.0)


### PR DESCRIPTION
## Description

Extends the content processing pipeline to support multiple games, generating items for each active game with proper traceability.

## Changes

### Database Schema
- Added game_code column to llm_runs table (migration a1b2c3d4e5f6)
- Tracks which game was used for each LLM call

### Pipeline Logic
- Modified process_content_upload to query active games from Game table
- Iterates over each active game and generates items per game
- Uses game-specific prompt_version and engine_version
- Stores source_game in items to track which game generated each item

### Helper Functions
- Updated _log_llm_attempt() to accept game_code parameter
- Updated _call_with_retries() to pass game_code through
- All existing calls pass game_code=None for backward compatibility

## Testing

-  Linting passes
-  Formatting passes
-  CI tests pending

## Related

- Fixes #157 (Sprint 8 Day 2)
- Depends on #159 (Sprint 8 Day 1 - merged)

## Breaking Changes

> [!WARNING]
> This change will increase processing time and LLM costs as it generates items for ALL active games (QUIZ, MATCH, CLOZE, etc.). Games can be deactivated via the admin panel to control costs.

## Next Steps

After merge, Day 3 will implement the admin panel UI to manage games.