### PR TITLE
feat: Sprint 8 Day 3 - Admin Games Panel

### DIFF
--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -71,3 +71,27 @@ export async function updateAdminActivityType(
   return res.data as AdminActivityType;
 }
 
+export interface AdminGame {
+  code: string;
+  name: string;
+  item_type: string;
+  active: boolean;
+  has_content: boolean;
+  last_processed_at: string | null;
+  prompt_version: string;
+  engine_version: string;
+}
+
+export async function fetchAdminGames(): Promise<AdminGame[]> {
+  const res = await api.get("/admin/games");
+  return res.data as AdminGame[];
+}
+
+export async function updateAdminGame(
+  code: string,
+  payload: { active?: boolean },
+): Promise<AdminGame> {
+  const res = await api.patch(`/admin/games/${code}`, payload);
+  return res.data as AdminGame;
+}
+


### PR DESCRIPTION
Implements the Games admin panel for managing game activation/deactivation.

## Changes
- Added `AdminGame` interface and API functions to admin service
- - Added Games tab to admin panel following existing pattern
- - Implemented `AdminGamesPanel` component with:
-   - Table displaying game information
-   - Toggle functionality for activating/deactivating games
-   - Content validation modal when activating games without content
-   - Loading and error states
Fixes #158